### PR TITLE
Handle break statements on for loops

### DIFF
--- a/builder.cc
+++ b/builder.cc
@@ -88,6 +88,14 @@ SigSpec RTLILBuilder::LogicAnd(SigSpec a, SigSpec b) {
 	return canvas->LogicAnd(NEW_ID, a, b);
 }
 
+SigSpec RTLILBuilder::LogicOr(SigSpec a, SigSpec b) {
+	if (a.is_fully_ones() || b.is_fully_ones())
+		return RTLIL::Const(1, 1);
+	if (a.is_fully_zero() && b.is_fully_zero())
+		return RTLIL::Const(0, 1);
+	return canvas->LogicOr(NEW_ID, a, b);
+}
+
 SigSpec RTLILBuilder::LogicNot(SigSpec a) {
 	if (a.is_fully_const())
 		return RTLIL::const_logic_not(a.as_const(), RTLIL::Const(), false, false, -1);

--- a/slang_frontend.cc
+++ b/slang_frontend.cc
@@ -987,7 +987,7 @@ public:
 		}
 
 		RTLIL::Wire *disable = netlist.canvas->addWire(NEW_ID_SUFFIX("disable"), 1);
-		disable->attributes[ID($nonstatic)] = 1;
+		disable->attributes[ID($nonstatic)] = current_case->level;
 		do_simple_assign(stmt.sourceRange.start(), disable, RTLIL::S0, true);
 
 		while (true) {

--- a/slang_frontend.cc
+++ b/slang_frontend.cc
@@ -986,14 +986,14 @@ public:
 			return;
 		}
 
-		SwitchHelper b(current_case, vstate, {RTLIL::S0});
-		b.sw->statement = &stmt;
-
 		RTLIL::Wire *disable = netlist.canvas->addWire(NEW_ID_SUFFIX("disable"), 1);
 		disable->attributes[ID($nonstatic)] = 1;
 		do_simple_assign(stmt.sourceRange.start(), disable, RTLIL::S0, true);
 
 		while (true) {
+			SwitchHelper b(current_case, vstate, {RTLIL::S0});
+			b.sw->statement = &stmt;
+
 			RTLIL::SigSpec cv = eval(*stmt.stopExpr);
 			if (!cv.is_fully_const()) {
 				auto& diag = diag_scope->addDiag(diag::ForLoopIndeterminate, stmt.sourceRange);
@@ -1016,8 +1016,8 @@ public:
 				eval(*step);
 
 			ncycles++;
+			b.finish(netlist);
 		}
-		b.finish(netlist);
 		current_case = current_case->add_switch({})->add_case({});
 	}
 

--- a/slang_frontend.h
+++ b/slang_frontend.h
@@ -29,6 +29,8 @@ struct SignalEvalContext {
 	struct Frame {
 		Yosys::dict<const ast::Symbol *, RTLIL::Wire *> locals;
 		const ast::SubroutineSymbol *subroutine;
+		std::vector<RTLIL::Wire*> disableLoop_ins;
+		std::vector<RTLIL::SigSpec> disableLoop_outs;
 	};
 
 	std::vector<Frame> frames;
@@ -65,6 +67,7 @@ struct RTLILBuilder {
 	SigSpec EqWildcard(RTLIL::SigSpec a, RTLIL::SigSpec b);
 	SigSpec Eq(SigSpec a, SigSpec b);
 	SigSpec LogicAnd(SigSpec a, SigSpec b);
+	SigSpec LogicOr(SigSpec a, SigSpec b);
 	SigSpec LogicNot(SigSpec a);
 	SigSpec Mux(SigSpec a, SigSpec b, SigSpec s);
 	SigSpec Bwmux(SigSpec a, SigSpec b, SigSpec s);

--- a/slang_frontend.h
+++ b/slang_frontend.h
@@ -34,7 +34,7 @@ struct SignalEvalContext {
 
 	std::vector<Frame> frames;
 
-	void push_frame(const ast::SubroutineSymbol *subroutine=nullptr);
+	void push_frame(const ast::SubroutineSymbol *subroutine=nullptr, RTLIL::Wire *loopDisable=nullptr);
 	void create_local(const ast::Symbol *symbol);
 	void pop_frame();
 	RTLIL::Wire *wire(const ast::Symbol &symbol);

--- a/slang_frontend.h
+++ b/slang_frontend.h
@@ -29,8 +29,7 @@ struct SignalEvalContext {
 	struct Frame {
 		Yosys::dict<const ast::Symbol *, RTLIL::Wire *> locals;
 		const ast::SubroutineSymbol *subroutine;
-		std::vector<RTLIL::Wire*> disableLoop_ins;
-		std::vector<RTLIL::SigSpec> disableLoop_outs;
+		RTLIL::Wire* loopDisableWire;
 	};
 
 	std::vector<Frame> frames;

--- a/tests/selects/all.tcl
+++ b/tests/selects/all.tcl
@@ -5,7 +5,7 @@ proc module_list {} {
 	return [dict keys [dict get $stat modules]]
 }
 
-foreach fn {bitsel.v indexed_down.v indexed_up.v} {
+foreach fn {bitsel.v indexed_down.v indexed_up.v priority_encoder.sv} {
 	log -header "Testset $fn"
 	log -push
 	design -reset

--- a/tests/selects/priority_encoder.sv
+++ b/tests/selects/priority_encoder.sv
@@ -1,0 +1,37 @@
+module priority_encoder #(
+    parameter integer INPUT_WIDTH = 8
+) (
+    input logic [INPUT_WIDTH-1:0] bits,
+    output logic [$clog2(INPUT_WIDTH)-1:0] encoded
+);
+    always_comb begin: for_loop_priority_encoder
+        encoded = 1'b0;
+        for (integer unsigned i = 0; i < INPUT_WIDTH; i++) begin
+            if (bits[i]) begin
+                encoded = i;
+                break;
+            end
+        end
+    end
+    always_comb begin
+        if (bits == 'd0 || ^bits === 1'bx) begin
+        end else begin
+            integer previousSet = 0;
+            for (integer unsigned i = 0; i < INPUT_WIDTH; i++) begin
+                if (bits[i]) begin
+                    if (previousSet == 0) begin
+                        assert(encoded == i);
+                        previousSet = 1;
+                    end
+                end
+            end
+
+        end
+    end
+endmodule
+
+module test_0 (bits, encoded);
+    input  logic[2:0] bits;
+    output logic[1:0] encoded;
+    priority_encoder #(3) test_0_inst (.*);
+endmodule


### PR DESCRIPTION
First attempt at disabling loop iterations whenever a break statement is found. In #19 it was discussed to transform the loop into a parallel case, but I ended up just adding a conditional for each iteration and adding the or-reduce with.

For now i've tested the code with:
```verilog
module forbreak (
    input logic [7:0] bits,
    output logic [2:0] encoded
);
    always_comb begin: for_with_break
        encoded = 1'b0;
        for (integer unsigned i = 0; i < 8; i++) begin
            if (bits[i]) begin
                encoded = i;
                break;
            end
        end
    end
endmodule
```
And manually checking the truth table. It would be nice to also add a test for this.

Any suggestion is welcome!