### PR TITLE
Allow bit selection on all bitstream-convertible signals

### DIFF
--- a/slang_frontend.cc
+++ b/slang_frontend.cc
@@ -1177,7 +1177,7 @@ RTLIL::SigSpec SignalEvalContext::lhs(const ast::Expression &expr)
 	case ast::ExpressionKind::ElementSelect:
 		{
 			const ast::ElementSelectExpression &elemsel = expr.as<ast::ElementSelectExpression>();
-			require(expr, elemsel.value().type->isArray() && elemsel.value().type->hasFixedRange());
+			require(expr, elemsel.value().type->isBitstreamType() && elemsel.value().type->hasFixedRange());
 			Addressing addr(*this, elemsel);
 			ret = addr.extract(lhs(elemsel.value()), elemsel.type->getBitstreamWidth());
 		}

--- a/tests/selects/all.tcl
+++ b/tests/selects/all.tcl
@@ -5,7 +5,7 @@ proc module_list {} {
 	return [dict keys [dict get $stat modules]]
 }
 
-foreach fn {bitsel.v indexed_down.v indexed_up.v priority_encoder.sv} {
+foreach fn {bitsel.v indexed_down.v indexed_up.v priority_encoder.sv struct_bit_select.sv} {
 	log -header "Testset $fn"
 	log -push
 	design -reset

--- a/tests/selects/struct_bit_select.sv
+++ b/tests/selects/struct_bit_select.sv
@@ -1,0 +1,27 @@
+module t_base #(
+    parameter integer FIELD0_WIDTH = 4,
+    parameter integer FIELD1_WIDTH = 4
+) (
+    input logic [FIELD0_WIDTH-1:0] in0,
+    input logic [FIELD1_WIDTH-1:0] in1
+);
+    typedef struct packed {
+        logic [FIELD0_WIDTH-1:0] field0;
+        logic [FIELD1_WIDTH-1:0] field1;
+    } test_t;
+
+    test_t struct_signal;
+    assign struct_signal[FIELD0_WIDTH+FIELD1_WIDTH-1:FIELD1_WIDTH] = in0;
+    assign struct_signal[FIELD1_WIDTH-1:0] = in1;
+
+    always_comb begin
+        assert(struct_signal.field0 == in0);
+        assert(struct_signal.field1 == in1);
+    end
+endmodule
+
+module t01(in0, in1);
+    input logic [5:0] in0;
+    input logic [4:0] in1;
+    t_base #(6, 5) t (.*);
+endmodule


### PR DESCRIPTION
This should allow bit and range indexing of packed structs and other similar signals.

Btw, when writing the test I noticed there seems to be an issue when lowering from `assert` with a struct member access to a `$check` cell: somehow the arguments get lost. I will open an issue on this.