### PR TITLE
Add 'install' make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 SRC_DIR := $(dir $(firstword $(MAKEFILE_LIST)))
 VPATH := $(SRC_DIR)
 YOSYS_CONFIG := $(YOSYS_PREFIX)yosys-config
+PLUGINDIR:=$(shell $(YOSYS_CONFIG) --datdir)/plugins
 CXXFLAGS :=
 SRCS = $(wildcard $(SRC_DIR)/src/*.cc)
 OBJS = $(patsubst $(SRC_DIR)/src/%.cc,build/%.o,$(SRCS))
@@ -53,6 +54,10 @@ clean: clean-objects
 
 clean-all: clean clean-slang
 
+install: build/slang.so
+	mkdir -p $(PLUGINDIR)
+	cp $< $(PLUGINDIR)
+
 -include $(OBJS:.o=.d)
 build/%.o: src/%.cc build/slang_install/.built
 	@mkdir -p $(@D)
@@ -72,4 +77,4 @@ build/slang.so: $(OBJS)
 		build/slang_install/lib/libsvlang.a \
 		build/slang_install/lib/libfmt.a
 
-.PHONY: build configure-slang build-slang clean-slang clean-objects clean clean-all
+.PHONY: build configure-slang build-slang clean-slang clean-objects clean clean-all install

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Then build both slang and the `build/slang.so` plugin for Yosys:
 
 Use a custom `-jN` switch to build with `N` concurrent processes instead of matching the number of cores.
 
-The built plugin is placed at `build/slang.so`. Copy this file into the Yosys plugin directory, or use a full path to this file (instead of the `slang` shorthand) when loading the plugin.
+The built plugin is placed at `build/slang.so`. Copy this file into the Yosys plugin directory, which can be achieved through `make install`, or use a full path to this file (instead of the `slang` shorthand) when loading the plugin.
 
 ## Usage
 


### PR DESCRIPTION
Hi. I recently discovered this project and added yosys-slang to one of my Dockerfiles (https://github.com/PyFPGA/containers/blob/main/recipes/synthesis). I noticed that this typical option was missing, so I added it, taking inspiration from the ghdl-yosys-plugin.