### PR TITLE
Fix build for Windows mingw environment

### DIFF
--- a/cmake/FindYosys.cmake
+++ b/cmake/FindYosys.cmake
@@ -22,4 +22,20 @@ message(STATUS "yosys-config --cxxflags (filtered): ${YOSYS_CXXFLAGS}")
 add_library(yosys::yosys INTERFACE IMPORTED)
 target_compile_options(yosys::yosys INTERFACE ${YOSYS_CXXFLAGS})
 
+if(WIN32)
+    execute_process(
+        COMMAND ${YOSYS_CONFIG} --linkflags
+        OUTPUT_VARIABLE YOSYS_LINKFLAGS
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+    string(REGEX REPLACE " +" ";" YOSYS_LINKFLAGS ${YOSYS_LINKFLAGS})
+    list(FILTER YOSYS_LINKFLAGS INCLUDE REGEX "^-[L]")
+    message(STATUS "yosys-config --linkflags (filtered): ${YOSYS_LINKFLAGS}")
+
+    target_link_options(yosys::yosys INTERFACE ${YOSYS_LINKFLAGS})
+
+    target_link_libraries(yosys::yosys INTERFACE yosys_exe)
+endif()
+
 set(YOSYS_DATDIR ${YOSYS_DATDIR} PARENT_SCOPE)


### PR DESCRIPTION
Building plugins for Windows environment is a bit more complicated. It requires linking to additional library to enable resolving everything included in main executable. This patch adds extraction of needed link flags (location of yosys lib directory in this case) and adding just this required library. 
We can genearalize this by doing same thing as `yosys-config` also linking all from --libs but there is no need to be honest