### PR TITLE
Allow building as a static library that can be linked into Yosys itself

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,10 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 project(yosys-slang CXX)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
-if (APPLE)
+option(BUILD_AS_PLUGIN "Build yosys-slang as a plugin" ON)
+mark_as_advanced(BUILD_AS_PLUGIN)
+
+if (APPLE AND BUILD_AS_PLUGIN)
     # On Linux, the shared libraries can refer to symbols from the executable by default.
     # On macOS, this is not the default behavior and needs to be enabled explicitly.
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -undefined dynamic_lookup")
@@ -34,7 +37,7 @@ add_subdirectory(third_party/slang)
 
 # We're statically linking slang (and fmt) into our plugin, which itself is a shared library.
 # Unless we build the dependencies as PIC, linking will fail.
-set_target_properties(fmt PROPERTIES POSITION_INDEPENDENT_CODE ON)
-set_target_properties(slang_slang PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(fmt PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_AS_PLUGIN})
+set_target_properties(slang_slang PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_AS_PLUGIN})
 
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,12 @@
 find_package(Yosys)
 
-add_library(yosys-slang SHARED
+if (BUILD_AS_PLUGIN)
+    set(LIBRARY_TYPE SHARED)
+else()
+    set(LIBRARY_TYPE STATIC)
+endif()
+
+add_library(yosys-slang ${LIBRARY_TYPE}
     abort_helpers.cc
     addressing.h
     async_pattern.cc
@@ -18,20 +24,28 @@ add_library(yosys-slang SHARED
     slang_frontend.h
 )
 target_link_libraries(yosys-slang PRIVATE yosys::yosys slang::slang)
-set_target_properties(yosys-slang PROPERTIES
-    # Yosys assumes `.so` to be the suffix on all platforms, so the following is required to make
-    # `yosys -m slang` to work after installation on any platform.
-    PREFIX ""
-    OUTPUT_NAME "slang"
-    SUFFIX ".so"
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
-    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
-)
 
-if(WIN32)
-    # install .dll only
-    install(TARGETS yosys-slang RUNTIME DESTINATION ${YOSYS_DATDIR}/plugins)
+if (BUILD_AS_PLUGIN)
+    set_target_properties(yosys-slang PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+        # Yosys assumes `.so` to be the suffix on all platforms, so the following is required to make
+        # `yosys -m slang` to work after installation on any platform.
+        PREFIX ""
+        OUTPUT_NAME "slang"
+        SUFFIX ".so"
+    )
+
+    if (WIN32)
+        # install .dll only
+        install(TARGETS yosys-slang RUNTIME DESTINATION ${YOSYS_DATDIR}/plugins)
+    else()
+        # install .so/.dylib only
+        install(TARGETS yosys-slang LIBRARY DESTINATION ${YOSYS_DATDIR}/plugins)
+    endif()
 else()
-    # install .so/.dylib only
-    install(TARGETS yosys-slang LIBRARY DESTINATION ${YOSYS_DATDIR}/plugins)
+    set_target_properties(yosys-slang PROPERTIES
+        ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+        STATIC_LIBRARY_OPTIONS "$<TARGET_OBJECTS:fmt::fmt>;$<TARGET_OBJECTS:slang::slang>"
+    )
 endif()


### PR DESCRIPTION
To include the Slang frontend in Yosys without requiring any options or commands, add the following to the Yosys `Makefile.conf`:

    EXE_LINKFLAGS += -Wl,--push-state,--whole-archive .../libyosys-slang.a -Wl,--pop-state