### PR TITLE
Don't install fmt artifacts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ include(FetchContent)
 
 # The log will show "-- Using remote fmt library", but that is misleading,
 # as no network access will be done. (Our first declaration of `fmt` wins.)
+option(FMT_INSTALL OFF)
 FetchContent_Declare(
     fmt
     EXCLUDE_FROM_ALL


### PR DESCRIPTION
This only changes a default setting, i.e. it will not affect existing build trees.

Fixes #120.