### PR TITLE
log_debug is not define anymore

### DIFF
--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -49,6 +49,9 @@ using Yosys::log_id;
 using Yosys::log_signal;
 using Yosys::ys_debug;
 using Yosys::ceil_log2;
+#ifndef log_debug
+using Yosys::log_debug;
+#endif
 namespace RTLIL = ::Yosys::RTLIL;
 namespace ast = ::slang::ast;
 namespace ID = ::Yosys::RTLIL::ID;


### PR DESCRIPTION
This is compile fix after https://github.com/YosysHQ/yosys/pull/5078 is merged