### PR TITLE
Improved error handling for interconnect

### DIFF
--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -1352,6 +1352,10 @@ RTLIL::SigSpec EvalContext::operator()(ast::Expression const &expr)
 	RTLIL::SigSpec ret;
 	size_t repl_count;
 
+	// TODO: Interconnect (untyped) is unimplemented, waiting on slang width resolution
+	if (expr.type->isUntypedType())
+		unimplemented(expr);
+
 	ast_invariant(expr, expr.kind != ast::ExpressionKind::Streaming);
 	if (!(expr.type->isFixedSize() || expr.type->isVoid())) {
 		auto &diag = netlist.add_diag(diag::FixedSizeRequired, expr.sourceRange);


### PR DESCRIPTION
Improves error handling for #146 to this:

```
 /----------------------------------------------------------------------------\
 |  yosys -- Yosys Open SYnthesis Suite                                       |
 |  Copyright (C) 2012 - 2025  Claire Xenia Wolf <claire@yosyshq.com>         |
 |  Distributed under an ISC-like license, type "license" to see terms        |
 \----------------------------------------------------------------------------/
 Preqorsor 0.51.1 (git sha1 73ebe78db, ccache c++ 15.0.0 -fPIC -O3)

-- Executing script file `test.ys' --

1. Executing SLANG frontend.
Top level design units:
    top

{
  "kind": "NamedValue",
  "type": "untyped",
  "symbol": "5033341560 bus"
}
Source line tests/unit/interconnect.sv:4:7:     m mi(bus);
ERROR: Feature unimplemented at /Users/akashlevy/Documents/yosys-slang/src/slang_frontend.cc:1357, see AST and code line dump above
```