### PR TITLE
fix: wire_missing_ logs not getting written to non-TTY outputs

### DIFF
--- a/src/abort_helpers.cc
+++ b/src/abort_helpers.cc
@@ -103,6 +103,8 @@ template<typename T>
 	if (netlist.scopes_remap.empty()) {
 		log(" (none)\n");
 	}
+	// Ensure previous log() calls are written before exit
+	log_flush();
 	log_error("Internal frontend error at %s:%d, see details above\n", file, line);
 }
 

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -43,6 +43,7 @@ namespace slang {
 namespace slang_frontend {
 
 using Yosys::log;
+using Yosys::log_flush;
 using Yosys::log_error;
 using Yosys::log_warning;
 using Yosys::log_id;


### PR DESCRIPTION
- src/abort_helpers.cc::wire_missing_: Call Yosys::log_flush() before log_error to ensure previous log() calls are written before exit


---

Resolves #192 