### PR TITLE
Fix bit offset direction with unpacked structs

### DIFF
--- a/src/naming.cc
+++ b/src/naming.cc
@@ -29,9 +29,11 @@ static void subfield_names(VariableChunk chunk, int type_offset, const ast::Type
 	if (type->isStruct()) {
 		const ast::Scope *scope = &type->as<ast::Scope>();
 
-		for (auto &field : scope->template membersOfType<ast::FieldSymbol>())
-			subfield_names(chunk, type_offset + field.bitOffset, &field.getType(),
+		for (auto &field : scope->template membersOfType<ast::FieldSymbol>()) {
+			int field_offset = int(bitstream_member_offset(field));
+			subfield_names(chunk, type_offset + field_offset, &field.getType(),
 					prefix + "." + std::string(field.name), ret);
+		}
 	} else if (type->isArray() && !type->isSimpleBitVector()) {
 		log_assert(type->hasFixedRange());
 		auto range = type->getFixedRange();

--- a/src/procedural.cc
+++ b/src/procedural.cc
@@ -337,12 +337,13 @@ void ProceduralContext::assign_rvalue_inner(const ast::AssignmentExpression &ass
 				break;
 			}
 
-			int pad = acc.value().type->getBitstreamWidth() - acc.type->getBitstreamWidth() -
-					  member.bitOffset;
+			int bit_offset = bitstream_member_offset(member);
+			int parent_width = acc.value().type->getBitstreamWidth();
+			int pad = parent_width - acc.type->getBitstreamWidth() - bit_offset;
 			raw_mask = {RTLIL::SigSpec(RTLIL::S0, pad), raw_mask,
-					RTLIL::SigSpec(RTLIL::S0, member.bitOffset)};
+					RTLIL::SigSpec(RTLIL::S0, bit_offset)};
 			raw_rvalue = {RTLIL::SigSpec(RTLIL::Sx, pad), raw_rvalue,
-					RTLIL::SigSpec(RTLIL::Sx, member.bitOffset)};
+					RTLIL::SigSpec(RTLIL::Sx, bit_offset)};
 			raw_lexpr = &acc.value();
 		} break;
 		case ast::ExpressionKind::Concatenation: {

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -38,6 +38,7 @@ namespace slang {
 		class StreamingConcatenationExpression;
 		class ConversionExpression;
 		class AssignmentExpression;
+		class FieldSymbol;
 	};
 };
 
@@ -67,6 +68,12 @@ class VariableBit;
 class VariableChunk;
 struct ProcessTiming;
 class Case;
+
+// Slang stores `FieldSymbol::bitOffset` MSB-first inside unpacked structs, while
+// Yosys works with bitstream-serialization order (LSB-first). This helper
+// mirrors Slang's offset so every caller sees the physical bit index actually
+// used when flattening into a bitstream.
+uint64_t bitstream_member_offset(const ast::FieldSymbol &member);
 
 class Variable {
 public:

--- a/tests/various/expr.sv
+++ b/tests/various/expr.sv
@@ -244,4 +244,15 @@ function logic [4:0] f3();
 endfunction
 initial $t(f3());
 
+// unpacked struct write
+function unpacked_t f4();
+    unpacked_t x;
+    x.a = 1'bx;
+    x.b = 2'b01;
+    x.c = 1'bx;
+    x.d = 1'b0;
+    return x;
+endfunction
+initial $t(f4());
+
 endmodule


### PR DESCRIPTION
Fixes #250 

I created a new helper functions to handle bit offsets and used it instead of directly accessing bitOffset.  
Added the recommended test for writes to structs.