### PR TITLE
order_symbols_within_scope fix

### DIFF
--- a/src/variables.cc
+++ b/src/variables.cc
@@ -114,6 +114,10 @@ bool order_symbols_within_scope(const ast::Symbol *lhs, const ast::Symbol *rhs)
 			if (linst.arrayPath[i] != rinst.arrayPath[i])
 				return linst.arrayPath[i] < rinst.arrayPath[i];
 		}
+		auto lpath = lhs->getHierarchicalPath();
+		auto rpath = rhs->getHierarchicalPath();
+		if (lpath != rpath)
+			return lpath < rpath;
 		break;
 	}
 	default: break;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ set(ALL_TESTS
     various/issue227.ys
     various/issue240.ys
     various/issue50.ys
+    various/issue259.ys
     various/mem_inference.ys
     various/meminit.ys
     various/pragmas.ys

--- a/tests/various/issue259.ys
+++ b/tests/various/issue259.ys
@@ -1,0 +1,49 @@
+read_slang --top top <<EOF
+typedef struct packed {
+    logic                       valid;
+  } s_flit_req_t;
+
+typedef struct packed {
+    logic                       ready;
+  } s_flit_resp_t;
+
+interface router_if;
+   s_flit_req_t  req;
+   s_flit_resp_t resp;
+
+  modport send_flit (
+    output  req,
+    input   resp
+  );
+
+  modport recv_flit (
+    input   req,
+    output  resp
+  );
+
+endinterface // router_if
+module top();
+   router_if ns_con [2] ();
+   router_if sn_con [2] ();
+   localparam int NorthIdx = 0;
+   router u_router (
+        .north_send     (ns_con[NorthIdx]),
+        .north_recv     (sn_con[NorthIdx])
+      );
+endmodule // raven
+
+module router
+  (
+  router_if.send_flit   north_send,
+  router_if.recv_flit   north_recv
+);
+  s_flit_resp_t       [4:0] ext_resp_v_o;
+  s_flit_req_t        [4:0] ext_req_v_o;
+  always_comb begin : mapping_input_ports
+    north_recv.resp = ext_resp_v_o[0];
+    north_send.req = ext_req_v_o[0];
+  end
+endmodule
+EOF
+sat -verify
+


### PR DESCRIPTION
Fix #259 
I add addition check in order_symbols_within_scope for  ast::SymbolKind::Instance for proper comparison rather than log_abort()