### PR TITLE
Improve cell naming in assertion handling by using labels if available

### DIFF
--- a/tests/various/formal_stmts.sv
+++ b/tests/various/formal_stmts.sv
@@ -13,5 +13,9 @@ endmodule
 module m_labeled_assertions(input logic x, y, z);
 	always_comb my_assert: assert(x);
 	always_comb my_assume: assume(y);
-	always_comb my_cover: cover(z);
+	always_comb my_cover: begin
+		begin
+			cover(z);
+		end
+	end
 endmodule

--- a/tests/various/formal_stmts.ys
+++ b/tests/various/formal_stmts.ys
@@ -1,7 +1,6 @@
 read_slang formal_stmts.sv
 
 select -assert-count 6 t:$check
-dump m_assert
 select -assert-count 1 m_assert/t:$check r:FLAVOR=assert %i
 select -assert-count 1 m_assume/t:$check r:FLAVOR=assume %i
 select -assert-count 1 m_cover/t:$check r:FLAVOR=cover %i

--- a/tests/various/regress.sv
+++ b/tests/various/regress.sv
@@ -307,3 +307,15 @@ module r26_router
     north_send.req = ext_req_v_o[0];
   end
 endmodule
+
+// pr 268 try cause name conflict
+module r27_submodule();
+    always_comb begin
+        foo: assert(1);
+    end
+endmodule
+
+module r27();
+    wire foo;
+    r27_submodule bar();
+endmodule


### PR DESCRIPTION
When using immediate assertions with labels (e.g., ast: assert(cand);), the label name was not being preserved in the generated $check cell name. Instead, an auto-generated name like $13 was used, causing the label to be lost in downstream BTOR/YWB exports.