### PR TITLE
Add support for simple concurrent assertions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(yosys-slang ${LIBRARY_TYPE}
     slang_frontend.cc
     slang_frontend.h
     statements.h
+    sva.cc
     variables.cc
     variables.h
     ${CMAKE_CURRENT_BINARY_DIR}/version.h

--- a/src/diag.cc
+++ b/src/diag.cc
@@ -123,6 +123,9 @@ DiagCode ErrorNonconstantInitialEval(DiagSubsystem::Netlist, 1071);
 DiagCode DeprecatedOption(DiagSubsystem::Netlist, 1072);
 DiagCode GuessingInputPort(DiagSubsystem::Netlist, 1073);
 DiagCode UnsupportedSystemTask(DiagSubsystem::Netlist, 1074);
+DiagCode UnsupportedSVAFeature(DiagSubsystem::Netlist, 1075);
+DiagCode RepetitionsUnsupported(DiagSubsystem::Netlist, 1076);
+DiagCode SVAClockingRequiresEdge(DiagSubsystem::Netlist, 1077);
 
 DiagGroup unsynthesizable("unsynthesizable",
 		{IffUnsupported, GenericTimingUnsyn, BothEdgesUnsupported, ExpectingIfElseAload,
@@ -316,6 +319,15 @@ void setup_messages(slang::DiagnosticEngine &engine)
 
 	engine.setMessage(UnsupportedSystemTask, "unsupported system task '{}'");
 	engine.setSeverity(UnsupportedSystemTask, DiagnosticSeverity::Error);
+
+	engine.setMessage(UnsupportedSVAFeature, "encountered unsupported SVA feature");
+	engine.setSeverity(UnsupportedSVAFeature, DiagnosticSeverity::Error);
+
+	engine.setMessage(RepetitionsUnsupported, "repetitions unsupported");
+	engine.setSeverity(RepetitionsUnsupported, DiagnosticSeverity::Error);
+
+	engine.setMessage(SVAClockingRequiresEdge, "SVA clocking requires a signal edge");
+	engine.setSeverity(SVAClockingRequiresEdge, DiagnosticSeverity::Error);
 	// clang-format on
 }
 }; // namespace diag

--- a/src/diag.h
+++ b/src/diag.h
@@ -79,6 +79,9 @@ extern slang::DiagCode ErrorNonconstantInitialEval;
 extern slang::DiagCode DeprecatedOption;
 extern slang::DiagCode GuessingInputPort;
 extern slang::DiagCode UnsupportedSystemTask;
+extern slang::DiagCode UnsupportedSVAFeature;
+extern slang::DiagCode RepetitionsUnsupported;
+extern slang::DiagCode SVAClockingRequiresEdge;
 
 void setup_messages(slang::DiagnosticEngine &engine);
 }; // namespace diag

--- a/src/procedural.cc
+++ b/src/procedural.cc
@@ -105,7 +105,7 @@ RegisterEscapeConstructGuard::~RegisterEscapeConstructGuard()
 
 ProceduralContext::ProceduralContext(NetlistContext &netlist, ProcessTiming &timing)
 	: unroll_limit(netlist, netlist.settings.unroll_limit()), netlist(netlist), timing(timing),
-	  eval(netlist, *this)
+	  eval(*this)
 {
 	root_case = std::make_unique<Case>();
 	current_case = root_case->add_switch({})->add_case({});

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -848,6 +848,15 @@ void handle_display(ProceduralContext &context, const ast::CallExpression &call)
 	fmt.emit_rtlil(cell);
 }
 
+RTLIL::SigSpec EvalContext::sva(ast::Expression const &expr)
+{
+	bool in_sva_expression_save = in_sva_expression;
+	in_sva_expression = true;
+	auto ret = (*this)(expr);
+	in_sva_expression = in_sva_expression_save;
+	return ret;
+}
+
 RTLIL::SigSpec EvalContext::operator()(ast::Expression const &expr)
 {
 	RTLIL::Module *mod = netlist.canvas;
@@ -957,7 +966,7 @@ RTLIL::SigSpec EvalContext::operator()(ast::Expression const &expr)
 			ast_invariant(symbol, ast::ValueSymbol::isKind(symbol.kind));
 			Variable variable1 = variable(symbol.as<ast::ValueSymbol>());
 			log_assert((bool) variable1);
-			if (procedural) {
+			if (procedural && (!in_sva_expression || variable1.kind != Variable::Static)) {
 				if (procedural->timing.kind == ProcessTiming::Initial && ast::NetSymbol::isKind(symbol.kind)) {
 					netlist.add_diag(diag::ReadingNetStateFromInitialBlockUnsupported, expr.sourceRange);
 					ret = RTLIL::SigSpec(RTLIL::Sx, (int) expr.type->getBitstreamWidth());
@@ -1104,7 +1113,14 @@ RTLIL::SigSpec EvalContext::operator()(ast::Expression const &expr)
 	case ast::ExpressionKind::Conversion:
 		{
 			const ast::ConversionExpression &conv = expr.as<ast::ConversionExpression>();
-			if (conv.operand().kind != ast::ExpressionKind::Streaming) {
+			if (conv.isConstCast) {
+				// See IEEE Std 1800-2017 section 16.14.6: the insides of a const cast
+				// follow the rules of ordinary procedural evaluation
+				bool in_sva_expression_save = in_sva_expression;
+				in_sva_expression = false;
+				ret = apply_conversion(conv, (*this)(conv.operand()));
+				in_sva_expression = in_sva_expression_save;
+			} else if (conv.operand().kind != ast::ExpressionKind::Streaming) {
 				ret = apply_conversion(conv, (*this)(conv.operand()));
 			} else {
 				const ast::Type &to = conv.type->getCanonicalType();
@@ -1137,7 +1153,7 @@ RTLIL::SigSpec EvalContext::operator()(ast::Expression const &expr)
 		{
 			const ast::ElementSelectExpression &elemsel = expr.as<ast::ElementSelectExpression>();
 
-			if (netlist.is_inferred_memory(elemsel.value())) {
+			if (netlist.is_inferred_memory(elemsel.value()) && !in_sva_expression) {
 				int width = elemsel.type->getBitstreamWidth();
 				std::string id = netlist.id(elemsel.value()
 										.as<ast::ValueExpressionBase>().symbol);
@@ -1618,7 +1634,32 @@ public:
 
 	void handle(const ast::ProceduralBlockSymbol &symbol)
 	{
-		interpret(symbol);
+		if (symbol.isFromAssertion &&
+				symbol.procedureKind == ast::ProceduralBlockKind::Always) {
+			const ast::StatementBlockSymbol *block_symbol = nullptr;
+			const ast::Statement *body = &symbol.getBody();
+			if (ast::BlockStatement::isKind(body->kind)) {
+				auto &block = body->as<ast::BlockStatement>();
+				block_symbol = block.blockSymbol;
+				body = &block.body;
+			}
+			ast_invariant(symbol, ast::ConcurrentAssertionStatement::isKind(body->kind) ||
+									ast::ImmediateAssertionStatement::isKind(body->kind));
+			if (!netlist.settings.ignore_assertions.value_or(false)) {
+				if (ast::ConcurrentAssertionStatement::isKind(body->kind)) {
+					process_freestanding_sva_property(netlist, body->as<ast::ConcurrentAssertionStatement>(),
+													  block_symbol);
+				} else {
+					ProceduralContext procedure(netlist, ProcessTiming::implicit);
+					symbol.getBody().visit(StatementExecutor(procedure));
+					RTLIL::Process *rtlil_proc = netlist.canvas->addProcess(netlist.new_id());
+					transfer_attrs(netlist, symbol, rtlil_proc);
+					procedure.copy_case_tree_into(rtlil_proc->root_case);
+				}
+			}
+		} else {
+			interpret(symbol);
+		}
 	}
 
 	void handle(const ast::NetSymbol &symbol)

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -1311,8 +1311,8 @@ EvalContext::EvalContext(NetlistContext &netlist)
 {
 }
 
-EvalContext::EvalContext(NetlistContext &netlist, ProceduralContext &procedural)
-	: netlist(netlist), procedural(&procedural),
+EvalContext::EvalContext(ProceduralContext &procedural)
+	: netlist(procedural.netlist), procedural(&procedural),
 	  const_(ast::ASTContext(netlist.compilation.getRoot(), ast::LookupLocation::max))
 {
 }

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -159,7 +159,7 @@ struct EvalContext {
 	RTLIL::SigSpec connection_lhs(ast::AssignmentExpression const &assign);
 
 	EvalContext(NetlistContext &netlist);
-	EvalContext(NetlistContext &netlist, ProceduralContext &procedural);
+	EvalContext(ProceduralContext &procedural);
 
 	// for testing
 	bool ignore_ast_constants = false;

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -26,7 +26,9 @@ namespace slang {
 	class DiagnosticEngine;
 	class CommandLine;
 	namespace ast {
+		class AssertionExpr;
 		class Compilation;
+		class ConcurrentAssertionStatement;
 		class Symbol;
 		class Expression;
 		class SubroutineSymbol;
@@ -42,6 +44,7 @@ namespace slang {
 		class NetSymbol;
 		class ElementSelectExpression;
 		class RangeSelectExpression;
+		class StatementBlockSymbol;
 	};
 };
 
@@ -143,6 +146,10 @@ struct EvalContext {
 	// Evaluates the given symbols/expressions to their value in this context
 	RTLIL::SigSpec operator()(ast::Expression const &expr);
 
+	// Evaluates the given expression using SVA rules.
+	// See IEEE Std 1800-2017 section 16.14.6
+	RTLIL::SigSpec sva(ast::Expression const &expr);
+
 	// Evaluates the given expression, inserts an extra sign bit if need
 	// be so that the result can always be interpreted as a signed value
 	RTLIL::SigSpec eval_signed(ast::Expression const &expr);
@@ -163,6 +170,10 @@ struct EvalContext {
 
 	// for testing
 	bool ignore_ast_constants = false;
+
+	// Variable reading within SVA is special depending on whether the variable
+	// is static, automatic, or is part of an expression casted to `const`
+	bool in_sva_expression = false;
 
 	friend class EnterAutomaticScopeGuard;
 };
@@ -696,5 +707,13 @@ private:
 								   ProceduralContext &context, LValue &lvalue,
 								   RTLIL::SigSpec rvalue, RTLIL::SigSpec mask, bool blocking);
 };
+
+// sva.cc
+void process_sva_property(const ast::ConcurrentAssertionStatement &statement,
+						  const ast::StatementBlockSymbol *block,
+						  ProceduralContext &procedural, const ast::AssertionExpr &expr);
+void process_freestanding_sva_property(NetlistContext &netlist,
+									   const ast::ConcurrentAssertionStatement &statement,
+						  			   const ast::StatementBlockSymbol *block);
 
 };

--- a/src/statements.h
+++ b/src/statements.h
@@ -17,6 +17,162 @@
 
 namespace slang_frontend {
 
+struct SwitchHelper
+{
+	Case *parent;
+	Case *&current_case;
+	Switch *sw;
+
+	using VariableState = ProceduralContext::VariableState;
+
+	VariableState &vstate;
+	VariableState::Map save_map;
+	std::vector<std::tuple<Case *, VariableBits, RTLIL::SigSpec>> branch_updates;
+	bool entered = false, finished = false;
+
+	SwitchHelper(ProceduralContext &context, RTLIL::SigSpec signal)
+		: parent(context.current_case), current_case(context.current_case), vstate(context.vstate)
+	{
+		sw = parent->add_switch(signal);
+	}
+
+	~SwitchHelper()
+	{
+		log_assert(!entered);
+		log_assert(branch_updates.empty() || finished);
+	}
+
+	SwitchHelper(const SwitchHelper &) = delete;
+	SwitchHelper &operator=(const SwitchHelper &) = delete;
+	SwitchHelper(SwitchHelper &&other)
+		: parent(other.parent), current_case(other.current_case), sw(other.sw),
+		  vstate(other.vstate), entered(other.entered), finished(other.finished)
+	{
+		branch_updates.swap(other.branch_updates);
+		save_map.swap(other.save_map);
+		other.entered = false;
+		other.finished = false;
+	}
+
+	void enter_branch(std::vector<RTLIL::SigSpec> compare)
+	{
+		save_map.clear();
+		vstate.save(save_map);
+		log_assert(!entered);
+		log_assert(current_case == parent);
+		current_case = sw->add_case(compare);
+		entered = true;
+	}
+
+	void exit_branch()
+	{
+		log_assert(entered);
+		log_assert(current_case != parent);
+		Case *this_case = current_case;
+		current_case = parent;
+		entered = false;
+		auto updates = vstate.restore(save_map);
+		branch_updates.push_back(std::make_tuple(this_case, updates.first, updates.second));
+	}
+
+	void branch(std::vector<RTLIL::SigSpec> compare, std::function<void()> f)
+	{
+		// TODO: extend detection
+		if (compare.size() == 1 && compare[0].is_fully_def() && sw->signal.is_fully_def() &&
+				sw->signal != compare[0]) {
+			// dead branch
+			return;
+		}
+
+		enter_branch(compare);
+		f();
+		exit_branch();
+	}
+
+	void finish(NetlistContext &netlist)
+	{
+		VariableBits updated_anybranch;
+		for (auto &branch : branch_updates)
+			updated_anybranch.append(std::get<1>(branch));
+		updated_anybranch.sort_and_unify();
+
+		// end-of-scope variables
+		Yosys::pool<Variable> eos_variables;
+
+		auto &va = vstate.visible_assignments;
+		for (auto bit : updated_anybranch)
+			if (bit.variable.kind != Variable::Static && !va.count(bit))
+				eos_variables.insert(bit.variable);
+
+		for (auto chunk : updated_anybranch.chunks()) {
+			if (chunk.variable.kind != Variable::Static && eos_variables.count(chunk.variable)) {
+				for (uint64_t i = 0; i < chunk.bitwidth(); i++)
+					log_assert(!va.count(chunk[i]));
+
+				continue;
+			}
+
+			std::string name_suggestion;
+			if (auto symbol = chunk.variable.get_symbol())
+				name_suggestion = RTLIL::unescape_id(netlist.id(*symbol)) + chunk.slice_text();
+
+			AttributeGuard guard(netlist);
+			if (sw->statement)
+				transfer_attrs(netlist, *sw->statement, guard);
+
+			RTLIL::SigSpec w_default = vstate.evaluate(netlist, chunk);
+			RTLIL::SigSpec w = netlist.add_placeholder_signal(chunk.bitwidth(), name_suggestion);
+			parent->aux_actions.push_back(RTLIL::SigSig(w, w_default));
+			vstate.set(chunk, w);
+		}
+
+		for (auto &branch : branch_updates) {
+			Case *rule;
+			VariableBits target;
+			RTLIL::SigSpec source;
+			std::tie(rule, target, source) = branch;
+
+			int done = 0;
+			for (auto chunk : target.chunks()) {
+				if (eos_variables.count(chunk.variable)) {
+					done += (int)chunk.bitwidth();
+					continue;
+				}
+
+				// get the wire (or some part of it) which we created up above
+				RTLIL::SigSpec target_w;
+				for (uint64_t i = 0; i < chunk.bitwidth(); i++) {
+					log_assert(va.count(chunk[i]));
+					target_w.append(va.at(chunk[i]));
+				}
+
+				rule->aux_actions.push_back(
+						RTLIL::SigSig(target_w, source.extract(done, (int)chunk.bitwidth())));
+				done += (int)chunk.bitwidth();
+			}
+		}
+
+		finished = true;
+	}
+};
+
+static const ast::Statement *unwrap_statement(const ast::Statement *statement)
+{
+	switch (statement->kind) {
+	case ast::StatementKind::Block:
+		return unwrap_statement(&statement->as<ast::BlockStatement>().body);
+	case ast::StatementKind::List: {
+		auto &list = statement->as<ast::StatementList>();
+		if (list.list.size() == 1) {
+			return unwrap_statement(list.list[0]);
+		}
+		break;
+	}
+	default: break;
+	}
+	return statement;
+}
+
 struct StatementExecutor : public ast::ASTVisitor<StatementExecutor, ast::VisitFlags::Statements>
 {
 public:
@@ -30,165 +186,6 @@ public:
 		: netlist(context.netlist), context(context), eval(context.eval),
 		  unroll_limit(context.unroll_limit)
 	{}
-
-	struct SwitchHelper
-	{
-		Case *parent;
-		Case *&current_case;
-		Switch *sw;
-
-		using VariableState = ProceduralContext::VariableState;
-
-		VariableState &vstate;
-		VariableState::Map save_map;
-		std::vector<std::tuple<Case *, VariableBits, RTLIL::SigSpec>> branch_updates;
-		bool entered = false, finished = false;
-
-		SwitchHelper(ProceduralContext &context, RTLIL::SigSpec signal)
-			: parent(context.current_case), current_case(context.current_case),
-			  vstate(context.vstate)
-		{
-			sw = parent->add_switch(signal);
-		}
-
-		~SwitchHelper()
-		{
-			log_assert(!entered);
-			log_assert(branch_updates.empty() || finished);
-		}
-
-		SwitchHelper(const SwitchHelper &) = delete;
-		SwitchHelper &operator=(const SwitchHelper &) = delete;
-		SwitchHelper(SwitchHelper &&other)
-			: parent(other.parent), current_case(other.current_case), sw(other.sw),
-			  vstate(other.vstate), entered(other.entered), finished(other.finished)
-		{
-			branch_updates.swap(other.branch_updates);
-			save_map.swap(other.save_map);
-			other.entered = false;
-			other.finished = false;
-		}
-
-		void enter_branch(std::vector<RTLIL::SigSpec> compare)
-		{
-			save_map.clear();
-			vstate.save(save_map);
-			log_assert(!entered);
-			log_assert(current_case == parent);
-			current_case = sw->add_case(compare);
-			entered = true;
-		}
-
-		void exit_branch()
-		{
-			log_assert(entered);
-			log_assert(current_case != parent);
-			Case *this_case = current_case;
-			current_case = parent;
-			entered = false;
-			auto updates = vstate.restore(save_map);
-			branch_updates.push_back(std::make_tuple(this_case, updates.first, updates.second));
-		}
-
-		void branch(std::vector<RTLIL::SigSpec> compare, std::function<void()> f)
-		{
-			// TODO: extend detection
-			if (compare.size() == 1 && compare[0].is_fully_def() && sw->signal.is_fully_def() &&
-					sw->signal != compare[0]) {
-				// dead branch
-				return;
-			}
-
-			enter_branch(compare);
-			f();
-			exit_branch();
-		}
-
-		void finish(NetlistContext &netlist)
-		{
-			VariableBits updated_anybranch;
-			for (auto &branch : branch_updates)
-				updated_anybranch.append(std::get<1>(branch));
-			updated_anybranch.sort_and_unify();
-
-			// end-of-scope variables
-			Yosys::pool<Variable> eos_variables;
-
-			auto &va = vstate.visible_assignments;
-			for (auto bit : updated_anybranch)
-				if (bit.variable.kind != Variable::Static && !va.count(bit))
-					eos_variables.insert(bit.variable);
-
-			for (auto chunk : updated_anybranch.chunks()) {
-				if (chunk.variable.kind != Variable::Static &&
-						eos_variables.count(chunk.variable)) {
-					for (uint64_t i = 0; i < chunk.bitwidth(); i++)
-						log_assert(!va.count(chunk[i]));
-
-					continue;
-				}
-
-				std::string name_suggestion;
-				if (auto symbol = chunk.variable.get_symbol())
-					name_suggestion = RTLIL::unescape_id(netlist.id(*symbol)) + chunk.slice_text();
-
-				AttributeGuard guard(netlist);
-				if (sw->statement)
-					transfer_attrs(netlist, *sw->statement, guard);
-
-				RTLIL::SigSpec w_default = vstate.evaluate(netlist, chunk);
-				RTLIL::SigSpec w =
-						netlist.add_placeholder_signal(chunk.bitwidth(), name_suggestion);
-				parent->aux_actions.push_back(RTLIL::SigSig(w, w_default));
-				vstate.set(chunk, w);
-			}
-
-			for (auto &branch : branch_updates) {
-				Case *rule;
-				VariableBits target;
-				RTLIL::SigSpec source;
-				std::tie(rule, target, source) = branch;
-
-				int done = 0;
-				for (auto chunk : target.chunks()) {
-					if (eos_variables.count(chunk.variable)) {
-						done += (int)chunk.bitwidth();
-						continue;
-					}
-
-					// get the wire (or some part of it) which we created up above
-					RTLIL::SigSpec target_w;
-					for (uint64_t i = 0; i < chunk.bitwidth(); i++) {
-						log_assert(va.count(chunk[i]));
-						target_w.append(va.at(chunk[i]));
-					}
-
-					rule->aux_actions.push_back(
-							RTLIL::SigSig(target_w, source.extract(done, (int)chunk.bitwidth())));
-					done += (int)chunk.bitwidth();
-				}
-			}
-
-			finished = true;
-		}
-	};
-
-	static const ast::Statement *unwrap_statement(const ast::Statement *statement)
-	{
-		switch (statement->kind) {
-		case ast::StatementKind::Block:
-			return unwrap_statement(&statement->as<ast::BlockStatement>().body);
-		case ast::StatementKind::List: {
-			auto &list = statement->as<ast::StatementList>();
-			if (list.list.size() == 1) {
-				return unwrap_statement(list.list[0]);
-			}
-			break;
-		}
-		default: break;
-		}
-		return statement;
-	}
 
 	void handle(const ast::ImmediateAssertionStatement &statement)
 	{

--- a/src/statements.h
+++ b/src/statements.h
@@ -10,6 +10,8 @@
 
 #include "cases.h"
 #include "slang/ast/ASTVisitor.h"
+#include "slang/ast/TimingControl.h"
+#include "slang/ast/expressions/AssertionExpr.h"
 #include "slang_frontend.h"
 #include "variables.h"
 
@@ -226,13 +228,119 @@ public:
 
 	void handle(const ast::ConcurrentAssertionStatement &stmt)
 	{
-		if (!netlist.settings.ignore_assertions.value_or(false)) {
-			if (stmt.assertionKind == ast::AssertionKind::Expect) {
-				netlist.add_diag(diag::ExpectStatementUnsupported, stmt.sourceRange);
-			} else {
-				netlist.add_diag(diag::SVAUnsupported, stmt.sourceRange);
-			}
+		if (netlist.settings.ignore_assertions.value_or(false))
+			return;
+
+		if (stmt.assertionKind == ast::AssertionKind::Expect) {
+			netlist.add_diag(diag::ExpectStatementUnsupported, stmt.sourceRange);
+			return;
 		}
+
+		// Try to handle simple concurrent assertions of the form:
+		// assert property (@(posedge clk) disable iff (reset) expr);
+		const ast::AssertionExpr *propExpr = &stmt.propertySpec;
+
+		// Extract clocking if present
+		const ast::TimingControl *clocking = nullptr;
+		if (propExpr->kind == ast::AssertionExprKind::Clocking) {
+			auto &clockExpr = propExpr->as<ast::ClockingAssertionExpr>();
+			clocking = &clockExpr.clocking;
+			propExpr = &clockExpr.expr;
+		}
+
+		// Extract disable iff condition if present
+		const ast::Expression *disableCondition = nullptr;
+		if (propExpr->kind == ast::AssertionExprKind::DisableIff) {
+			auto &disableExpr = propExpr->as<ast::DisableIffAssertionExpr>();
+			disableCondition = &disableExpr.condition;
+			propExpr = &disableExpr.expr;
+		}
+
+		// The remaining expression should be a simple assertion expression
+		if (propExpr->kind != ast::AssertionExprKind::Simple) {
+			netlist.add_diag(diag::SVAUnsupported, stmt.sourceRange);
+			return;
+		}
+
+		auto &simpleExpr = propExpr->as<ast::SimpleAssertionExpr>();
+
+		// We don't support repetition in simple assertions
+		if (simpleExpr.repetition.has_value()) {
+			netlist.add_diag(diag::SVAUnsupported, stmt.sourceRange);
+			return;
+		}
+
+		// We need a clock for concurrent assertions
+		if (!clocking) {
+			netlist.add_diag(diag::SVAUnsupported, stmt.sourceRange);
+			return;
+		}
+
+		// The clocking must be a signal event (posedge/negedge)
+		if (clocking->kind != ast::TimingControlKind::SignalEvent) {
+			netlist.add_diag(diag::SVAUnsupported, stmt.sourceRange);
+			return;
+		}
+
+		auto &sigEvent = clocking->as<ast::SignalEventControl>();
+
+		// We don't support iff condition on the clock
+		if (sigEvent.iffCondition) {
+			netlist.add_diag(diag::SVAUnsupported, stmt.sourceRange);
+			return;
+		}
+
+		// We need posedge or negedge
+		if (sigEvent.edge != ast::EdgeKind::PosEdge && sigEvent.edge != ast::EdgeKind::NegEdge) {
+			netlist.add_diag(diag::SVAUnsupported, stmt.sourceRange);
+			return;
+		}
+
+		std::string flavor;
+		switch (stmt.assertionKind) {
+		case ast::AssertionKind::Assert:        flavor = "assert"; break;
+		case ast::AssertionKind::Assume:        flavor = "assume"; break;
+		case ast::AssertionKind::CoverProperty: flavor = "cover"; break;
+		default:                                netlist.add_diag(diag::AssertionUnsupported, stmt.sourceRange); return;
+		}
+
+		RTLIL::IdString cell_name;
+
+		if (containing_block && unwrap_statement(containing_block->tryGetStatement()) == &stmt &&
+				!containing_block->name.empty()) {
+			// If we are the sole statement in a block, use the block's label
+			cell_name = netlist.id(*containing_block);
+		} else {
+			cell_name = netlist.new_id();
+		}
+
+		auto cell = netlist.canvas->addCell(cell_name, ID($check));
+
+		// Set up the trigger (clock)
+		RTLIL::SigBit clk_sig = netlist.eval(sigEvent.expr);
+		bool clk_polarity = (sigEvent.edge == ast::EdgeKind::PosEdge);
+
+		cell->setParam(ID::TRG_ENABLE, true);
+		cell->setParam(ID::TRG_WIDTH, 1);
+		cell->setParam(ID::TRG_POLARITY, clk_polarity ? RTLIL::S1 : RTLIL::S0);
+		cell->setPort(ID::TRG, clk_sig);
+
+		// Set up the enable (disable iff inverted)
+		RTLIL::SigBit enable;
+		if (disableCondition) {
+			enable = netlist.LogicNot(netlist.ReduceBool(eval(*disableCondition)));
+		} else {
+			enable = RTLIL::S1;
+		}
+		cell->setPort(ID::EN, enable);
+
+		cell->setParam(ID::FLAVOR, flavor);
+		cell->setParam(ID::FORMAT, std::string(""));
+		cell->setParam(ID::ARGS_WIDTH, 0);
+		cell->setParam(ID::PRIORITY, --context.effects_priority);
+		cell->setPort(ID::ARGS, {});
+		cell->setPort(ID::A, netlist.ReduceBool(eval(simpleExpr.expr)));
+		transfer_attrs(netlist, stmt, cell);
 	}
 
 	RTLIL::SigSpec handle_call(const ast::CallExpression &call)

--- a/src/statements.h
+++ b/src/statements.h
@@ -10,8 +10,6 @@
 
 #include "cases.h"
 #include "slang/ast/ASTVisitor.h"
-#include "slang/ast/TimingControl.h"
-#include "slang/ast/expressions/AssertionExpr.h"
 #include "slang_frontend.h"
 #include "variables.h"
 
@@ -223,121 +221,15 @@ public:
 		transfer_attrs(netlist, statement, cell);
 	}
 
-	void handle(const ast::ConcurrentAssertionStatement &stmt)
+	void handle(const ast::ConcurrentAssertionStatement &statement)
 	{
-		if (netlist.settings.ignore_assertions.value_or(false))
-			return;
-
-		if (stmt.assertionKind == ast::AssertionKind::Expect) {
-			netlist.add_diag(diag::ExpectStatementUnsupported, stmt.sourceRange);
-			return;
+		if (!netlist.settings.ignore_assertions.value_or(false)) {
+			if (statement.assertionKind == ast::AssertionKind::Expect) {
+				netlist.add_diag(diag::ExpectStatementUnsupported, statement.sourceRange);
+			} else {
+				process_sva_property(statement, containing_block, context, statement.propertySpec);
+			}
 		}
-
-		// Try to handle simple concurrent assertions of the form:
-		// assert property (@(posedge clk) disable iff (reset) expr);
-		const ast::AssertionExpr *propExpr = &stmt.propertySpec;
-
-		// Extract clocking if present
-		const ast::TimingControl *clocking = nullptr;
-		if (propExpr->kind == ast::AssertionExprKind::Clocking) {
-			auto &clockExpr = propExpr->as<ast::ClockingAssertionExpr>();
-			clocking = &clockExpr.clocking;
-			propExpr = &clockExpr.expr;
-		}
-
-		// Extract disable iff condition if present
-		const ast::Expression *disableCondition = nullptr;
-		if (propExpr->kind == ast::AssertionExprKind::DisableIff) {
-			auto &disableExpr = propExpr->as<ast::DisableIffAssertionExpr>();
-			disableCondition = &disableExpr.condition;
-			propExpr = &disableExpr.expr;
-		}
-
-		// The remaining expression should be a simple assertion expression
-		if (propExpr->kind != ast::AssertionExprKind::Simple) {
-			netlist.add_diag(diag::SVAUnsupported, stmt.sourceRange);
-			return;
-		}
-
-		auto &simpleExpr = propExpr->as<ast::SimpleAssertionExpr>();
-
-		// We don't support repetition in simple assertions
-		if (simpleExpr.repetition.has_value()) {
-			netlist.add_diag(diag::SVAUnsupported, stmt.sourceRange);
-			return;
-		}
-
-		// We need a clock for concurrent assertions
-		if (!clocking) {
-			netlist.add_diag(diag::SVAUnsupported, stmt.sourceRange);
-			return;
-		}
-
-		// The clocking must be a signal event (posedge/negedge)
-		if (clocking->kind != ast::TimingControlKind::SignalEvent) {
-			netlist.add_diag(diag::SVAUnsupported, stmt.sourceRange);
-			return;
-		}
-
-		auto &sigEvent = clocking->as<ast::SignalEventControl>();
-
-		// We don't support iff condition on the clock
-		if (sigEvent.iffCondition) {
-			netlist.add_diag(diag::SVAUnsupported, stmt.sourceRange);
-			return;
-		}
-
-		// We need posedge or negedge
-		if (sigEvent.edge != ast::EdgeKind::PosEdge && sigEvent.edge != ast::EdgeKind::NegEdge) {
-			netlist.add_diag(diag::SVAUnsupported, stmt.sourceRange);
-			return;
-		}
-
-		std::string flavor;
-		switch (stmt.assertionKind) {
-		case ast::AssertionKind::Assert:        flavor = "assert"; break;
-		case ast::AssertionKind::Assume:        flavor = "assume"; break;
-		case ast::AssertionKind::CoverProperty: flavor = "cover"; break;
-		default:                                netlist.add_diag(diag::AssertionUnsupported, stmt.sourceRange); return;
-		}
-
-		RTLIL::IdString cell_name;
-
-		if (containing_block && unwrap_statement(containing_block->tryGetStatement()) == &stmt &&
-				!containing_block->name.empty()) {
-			// If we are the sole statement in a block, use the block's label
-			cell_name = netlist.id(*containing_block);
-		} else {
-			cell_name = netlist.new_id();
-		}
-
-		auto cell = netlist.canvas->addCell(cell_name, ID($check));
-
-		// Set up the trigger (clock)
-		RTLIL::SigBit clk_sig = netlist.eval(sigEvent.expr);
-		bool clk_polarity = (sigEvent.edge == ast::EdgeKind::PosEdge);
-
-		cell->setParam(ID::TRG_ENABLE, true);
-		cell->setParam(ID::TRG_WIDTH, 1);
-		cell->setParam(ID::TRG_POLARITY, clk_polarity ? RTLIL::S1 : RTLIL::S0);
-		cell->setPort(ID::TRG, clk_sig);
-
-		// Set up the enable (disable iff inverted)
-		RTLIL::SigBit enable;
-		if (disableCondition) {
-			enable = netlist.LogicNot(netlist.ReduceBool(eval(*disableCondition)));
-		} else {
-			enable = RTLIL::S1;
-		}
-		cell->setPort(ID::EN, enable);
-
-		cell->setParam(ID::FLAVOR, flavor);
-		cell->setParam(ID::FORMAT, std::string(""));
-		cell->setParam(ID::ARGS_WIDTH, 0);
-		cell->setParam(ID::PRIORITY, --context.effects_priority);
-		cell->setPort(ID::ARGS, {});
-		cell->setPort(ID::A, netlist.ReduceBool(eval(simpleExpr.expr)));
-		transfer_attrs(netlist, stmt, cell);
 	}
 
 	RTLIL::SigSpec handle_call(const ast::CallExpression &call)

--- a/src/sva.cc
+++ b/src/sva.cc
@@ -1,0 +1,149 @@
+//
+// Yosys slang frontend
+//
+// Copyright Martin Povišer <povik@cutebit.org>
+// Distributed under the terms of the ISC license, see LICENSE
+//
+// clang-format off
+#include "slang/ast/statements/MiscStatements.h"
+#include "slang/ast/expressions/AssertionExpr.h"
+#include "slang/ast/symbols/BlockSymbols.h"
+#include "slang/util/ScopeGuard.h"
+
+#include "slang_frontend.h"
+#include "statements.h"
+#include "diag.h"
+
+namespace slang_frontend {
+
+// Process a 'concurrent assertion'
+//
+// Any top level clocking expressions have been stripped. Clocking is part
+// of the created procedural context.
+void process_sva_property(const ast::ConcurrentAssertionStatement &statement,
+						  const ast::StatementBlockSymbol *block,
+						  ProceduralContext &procedural, const ast::AssertionExpr &top_expr)
+{
+	auto &netlist = procedural.netlist;
+
+	const ast::AssertionExpr *expr = &top_expr;
+	slang::SourceRange source_range = expr->syntax ? expr->syntax->sourceRange() : statement.sourceRange;
+
+	// Extract disable iff condition if present; the extracted switch
+	// needs to live until the end of the function to be picked up
+	// by set_effects_trigger
+	std::optional<SwitchHelper> switch_;
+	auto guard = slang::ScopeGuard([&] {
+		if (switch_.has_value()) {
+			switch_->exit_branch();
+			switch_->finish(netlist);
+		}
+	});
+	if (ast::DisableIffAssertionExpr::isKind(expr->kind)) {
+		auto &disable = expr->as<ast::DisableIffAssertionExpr>();
+		switch_.emplace(procedural, netlist.ReduceBool(procedural.eval.sva(disable.condition)));
+		switch_->enter_branch({RTLIL::S0});
+		expr = &disable.expr;
+		source_range = expr->syntax ? expr->syntax->sourceRange() : statement.sourceRange;
+	}
+
+	if (!ast::SimpleAssertionExpr::isKind(expr->kind)) {
+		netlist.add_diag(diag::UnsupportedSVAFeature, source_range);
+		return;
+	}
+
+	auto &simple_assertion = expr->as<ast::SimpleAssertionExpr>();
+
+	// We don't support repetition in simple assertions
+	if (simple_assertion.repetition.has_value()) {
+		netlist.add_diag(diag::RepetitionsUnsupported, source_range);
+		return;
+	}
+
+	std::string flavor;
+	switch (statement.assertionKind) {
+	case ast::AssertionKind::Assert:        flavor = "assert"; break;
+	case ast::AssertionKind::Assume:        flavor = "assume"; break;
+	case ast::AssertionKind::CoverProperty: flavor = "cover"; break;
+	default:                                netlist.add_diag(diag::AssertionUnsupported, statement.sourceRange); return;
+	}
+
+	RTLIL::IdString cell_name;
+
+	if (block && unwrap_statement(block->tryGetStatement()) == &statement && !block->name.empty()) {
+		// If we are the sole statement in a block, use the block's label
+		cell_name = netlist.id(*block);
+	} else {
+		cell_name = netlist.new_id();
+	}
+
+	RTLIL::SigSpec a = netlist.ReduceBool(procedural.eval.sva(simple_assertion.expr));
+
+	auto cell = netlist.canvas->addCell(cell_name, ID($check));
+	procedural.set_effects_trigger(cell);
+	cell->setParam(ID::FLAVOR, flavor);
+	cell->setParam(ID::FORMAT, std::string(""));
+	cell->setParam(ID::ARGS_WIDTH, 0);
+	cell->setParam(ID::PRIORITY, --procedural.effects_priority);
+	cell->setPort(ID::ARGS, {});
+	cell->setPort(ID::A, a);
+	transfer_attrs<const ast::Statement>(netlist, statement, cell);
+}
+
+void process_freestanding_sva_property(NetlistContext &netlist,
+									   const ast::ConcurrentAssertionStatement &statement,
+						  			   const ast::StatementBlockSymbol *block)
+{
+	const ast::AssertionExpr &spec = statement.propertySpec;
+
+	if (ast::ClockingAssertionExpr::isKind(spec.kind)) {
+		// Need to strip clocking
+		const auto &clocking_expr = spec.as<ast::ClockingAssertionExpr>();
+		const auto &clocking = clocking_expr.clocking;
+
+		if (!ast::SignalEventControl::isKind(clocking.kind)) {
+			netlist.add_diag(diag::UnsupportedSVAFeature, clocking.sourceRange);
+			return;
+		}
+
+		const auto &signal_event = clocking.as<ast::SignalEventControl>();
+
+		ProcessTiming timing(ProcessTiming::EdgeTriggered);
+		switch (signal_event.edge) {
+		case ast::EdgeKind::None:
+			netlist.add_diag(diag::SVAClockingRequiresEdge, signal_event.sourceRange);
+			return;
+
+		case ast::EdgeKind::PosEdge:
+		case ast::EdgeKind::NegEdge:
+			timing.triggers.push_back(ProcessTiming::Sensitivity {
+				.signal = netlist.eval(signal_event.expr),
+				.edge_polarity = (signal_event.edge == ast::EdgeKind::PosEdge),
+				.ast_node = &clocking
+			});
+			break;
+
+		case ast::EdgeKind::BothEdges:
+			netlist.add_diag(diag::BothEdgesUnsupported, signal_event.sourceRange);
+			return;
+		}
+
+		if (signal_event.iffCondition) {
+			// TODO
+			netlist.add_diag(diag::IffUnsupported, signal_event.iffCondition->sourceRange);
+		}
+
+		ProceduralContext procedure(netlist, timing);
+		process_sva_property(statement, block, procedure, clocking_expr.expr);
+
+		RTLIL::Process *rtlil_proc = netlist.canvas->addProcess(netlist.new_id());
+		transfer_attrs<const ast::Statement>(netlist, statement, rtlil_proc);
+		procedure.copy_case_tree_into(rtlil_proc->root_case);
+	} else {
+		// No clocking
+		ProceduralContext procedure(netlist, ProcessTiming::implicit);
+		process_sva_property(statement, block, procedure, spec);
+	}
+}
+
+};

--- a/src/sva.cc
+++ b/src/sva.cc
@@ -143,6 +143,10 @@ void process_freestanding_sva_property(NetlistContext &netlist,
 		// No clocking
 		ProceduralContext procedure(netlist, ProcessTiming::implicit);
 		process_sva_property(statement, block, procedure, spec);
+
+		RTLIL::Process *rtlil_proc = netlist.canvas->addProcess(netlist.new_id());
+		transfer_attrs<const ast::Statement>(netlist, statement, rtlil_proc);
+		procedure.copy_case_tree_into(rtlil_proc->root_case);
 	}
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(ALL_TESTS
     various/bb_detect.ys
     various/blackbox_scenarios.ys
     various/bus_range.ys
+    various/concurrent_assert.ys
     various/defaults.ys
     various/delays.ys
     various/dualedge.ys

--- a/tests/unit/sva.sv
+++ b/tests/unit/sva.sv
@@ -1,0 +1,18 @@
+module test_sva_edge_cases (input clk, input a, input b, input c);
+	always_comb begin
+		if (^{a, b, c} !== 'x) begin
+			if (a) begin
+				foo: assert property (disable iff (a) b);
+			end
+		end
+	end
+
+	always_comb begin
+		int i;
+		automatic int j = 0;
+		i = 0;
+		bar1: assert property (i == 1 && const'(i) == 0 && j == 0);
+		i++;
+		j++;
+	end
+endmodule

--- a/tests/unit/sva.sv
+++ b/tests/unit/sva.sv
@@ -15,4 +15,6 @@ module test_sva_edge_cases (input clk, input a, input b, input c);
 		i++;
 		j++;
 	end
+
+	assert property (disable iff (!c) c);
 endmodule

--- a/tests/various/concurrent_assert.sv
+++ b/tests/various/concurrent_assert.sv
@@ -1,0 +1,38 @@
+// Test simple concurrent assertions
+module m_concurrent_assert(input clk, input rst_n, input [7:0] data);
+	// Basic posedge assertion
+	assert property (@(posedge clk) data != 8'hFF);
+endmodule
+
+module m_concurrent_assume(input clk, input [7:0] data);
+	// Basic posedge assume
+	assume property (@(posedge clk) data != 8'h00);
+endmodule
+
+module m_concurrent_cover(input clk, input valid);
+	// Basic posedge cover
+	cover property (@(posedge clk) valid);
+endmodule
+
+module m_negedge_assert(input clk, input [7:0] data);
+	// Negedge assertion
+	assert property (@(negedge clk) data != 8'hAA);
+endmodule
+
+module m_disable_iff(input clk, input rst_n, input [7:0] data);
+	// Assertion with disable iff
+	assert property (@(posedge clk) disable iff (!rst_n) data != 8'hFF);
+endmodule
+
+module m_multiple_concurrent(input clk, input rst_n, input [7:0] data, input valid);
+	// Multiple concurrent assertions in one module
+	assert property (@(posedge clk) disable iff (!rst_n) data != 8'hFF);
+	assume property (@(posedge clk) disable iff (!rst_n) data[7] == 1'b0);
+	cover property (@(posedge clk) valid && data == 8'hAA);
+	assert property (@(negedge clk) data != 8'h00);
+endmodule
+
+module m_labeled_concurrent(input clk, input rst_n, input [7:0] data);
+	// Labeled concurrent assertion
+	my_concurrent_assert: assert property (@(posedge clk) disable iff (!rst_n) data != 8'hFF);
+endmodule

--- a/tests/various/concurrent_assert.ys
+++ b/tests/various/concurrent_assert.ys
@@ -1,0 +1,37 @@
+read_slang concurrent_assert.sv
+
+# Test basic concurrent assertions exist
+select -assert-count 10 t:$check
+
+# Test m_concurrent_assert: posedge clk, no disable iff
+select -assert-count 1 m_concurrent_assert/t:$check
+select -assert-count 1 m_concurrent_assert/t:$check r:FLAVOR=assert %i
+select -assert-count 1 m_concurrent_assert/t:$check r:TRG_ENABLE=1 %i
+select -assert-count 1 m_concurrent_assert/t:$check r:TRG_POLARITY=1'1 %i
+
+# Test m_concurrent_assume: posedge clk, assume flavor
+select -assert-count 1 m_concurrent_assume/t:$check
+select -assert-count 1 m_concurrent_assume/t:$check r:FLAVOR=assume %i
+
+# Test m_concurrent_cover: posedge clk, cover flavor
+select -assert-count 1 m_concurrent_cover/t:$check
+select -assert-count 1 m_concurrent_cover/t:$check r:FLAVOR=cover %i
+
+# Test m_negedge_assert: negedge clk (TRG_POLARITY=0)
+select -assert-count 1 m_negedge_assert/t:$check
+select -assert-count 1 m_negedge_assert/t:$check r:TRG_POLARITY=1'0 %i
+
+# Test m_disable_iff: posedge clk with disable iff
+select -assert-count 1 m_disable_iff/t:$check
+select -assert-count 1 m_disable_iff/t:$check r:FLAVOR=assert %i
+
+# Test m_multiple_concurrent: 4 assertions (1 assert posedge, 1 assume, 1 cover, 1 assert negedge)
+select -assert-count 4 m_multiple_concurrent/t:$check
+select -assert-count 2 m_multiple_concurrent/t:$check r:FLAVOR=assert %i
+select -assert-count 1 m_multiple_concurrent/t:$check r:FLAVOR=assume %i
+select -assert-count 1 m_multiple_concurrent/t:$check r:FLAVOR=cover %i
+select -assert-count 1 m_multiple_concurrent/t:$check r:TRG_POLARITY=1'0 %i
+
+# Test m_labeled_concurrent: labeled assertion
+select -assert-count 1 m_labeled_concurrent/t:$check
+select -assert-count 1 m_labeled_concurrent/t:$check n:*my_concurrent_assert %i


### PR DESCRIPTION
**This PR was fully generated by Claude Opus 4.6.**

This PR adds support for synthesizing simple concurrent assertions in SystemVerilog.

## Supported syntax

```systemverilog
assert property (@(posedge clk) expr);
assert property (@(negedge clk) expr);
assert property (@(posedge clk) disable iff (!rst_n) expr);
assume property (@(posedge clk) disable iff (!rst_n) expr);
cover property (@(posedge clk) expr);
```

Implementation

The concurrent assertion is converted to a $check cell with:
- TRG port connected to the clock signal
- TRG_POLARITY set based on posedge (1) or negedge (0)
- EN port set to the inverted disable condition (or constant 1 if no disable iff)
- FLAVOR parameter set to "assert", "assume", or "cover"

Limitations

The following SVA features are NOT supported and will still produce the "SVA unsupported" error:
- Sequence operators (##, [*], [->], etc.)
- Implication operators (|->, |=>)
- Property operators (not, and, or, until, etc.)
- Repetition in simple expressions
- Clock with iff condition (@(posedge clk iff en))

Test

Added tests/various/concurrent_assert.sv and tests/various/concurrent_assert.ys to verify the implementation.

Fixes the error for simple concurrent assertions like:
assert property (@(posedge clk) disable iff (!rst_n) count != {(W - 4) {1'b1}});