### PR TITLE
Add clog2 system call lowering

### DIFF
--- a/src/builder.cc
+++ b/src/builder.cc
@@ -565,6 +565,23 @@ SigSpec RTLILBuilder::CountOnes(SigSpec sig, int result_width)
 	return ret;
 }
 
+SigSpec RTLILBuilder::Clog2(SigSpec sig, int result_width)
+{
+	int width = sig.size();
+
+	if (width == 0)
+		return RTLIL::Const(0, result_width);
+
+	SigSpec n_minus_1 = Biop(ID($sub), sig, RTLIL::Const(1, width), false, false, width);
+
+	SigSpec result = RTLIL::Const(0, result_width);
+	for (int i = 0; i < width; i++)
+		result = Mux(result, RTLIL::Const(i + 1, result_width), n_minus_1[i]);
+
+	SigSpec n_not_zero = ReduceBool(sig);
+	return Mux(RTLIL::Const(0, result_width), result, n_not_zero);
+}
+
 static const RTLIL::Const reverse_data(RTLIL::Const &orig, int width)
 {
 	std::vector<RTLIL::State> bits;

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -1229,6 +1229,11 @@ RTLIL::SigSpec EvalContext::operator()(ast::Expression const &expr)
 					auto arg = call.arguments()[0];
 					auto sig = (*this)(*arg);
 					ret = netlist.CountOnes(sig, (int)call.type->getBitstreamWidth());
+				} else if (name == "$clog2") {
+					require(expr, call.arguments().size() == 1);
+					auto arg = call.arguments()[0];
+					auto sig = (*this)(*arg);
+					ret = netlist.Clog2(sig, (int)call.type->getBitstreamWidth());
 				} else if (name == "$past") {
 					ret = handle_past(*this, call);
 				} else if (name == "$signed" || name == "$unsigned") {

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -1230,7 +1230,7 @@ RTLIL::SigSpec EvalContext::operator()(ast::Expression const &expr)
 					auto sig = (*this)(*arg);
 					ret = netlist.CountOnes(sig, (int)call.type->getBitstreamWidth());
 				} else if (name == "$clog2") {
-					require(expr, call.arguments().size() == 1);
+					ast_invariant(expr, call.arguments().size() == 1);
 					auto arg = call.arguments()[0];
 					auto sig = (*this)(*arg);
 					ret = netlist.Clog2(sig, (int)call.type->getBitstreamWidth());

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -358,6 +358,7 @@ struct RTLILBuilder {
 				 bool a_signed, bool b_signed, int y_width);
 
 	SigSpec CountOnes(SigSpec sig, int result_width);
+	SigSpec Clog2(SigSpec sig, int result_width);
 
 	void add_dual_edge_aldff(const std::string &base_name, RTLIL::SigSpec clk,
 							 RTLIL::SigSpec aload, RTLIL::SigSpec d, RTLIL::SigSpec q,

--- a/tests/unit/clog2.sv
+++ b/tests/unit/clog2.sv
@@ -1,0 +1,37 @@
+// Test $clog2 lowering to RTLIL
+module clog2_constants;
+    always_comb begin
+        assert($clog2(0) == 0);
+        assert($clog2(1) == 0);
+        assert($clog2(2) == 1);
+        assert($clog2(3) == 2);
+        assert($clog2(4) == 2);
+        assert($clog2(5) == 3);
+        assert($clog2(8) == 3);
+        assert($clog2(9) == 4);
+        assert($clog2(16) == 4);
+        assert($clog2(255) == 8);
+        assert($clog2(256) == 8);
+        assert($clog2(257) == 9);
+    end
+endmodule
+
+// Test with a variable input, verifying against a reference implementation
+module clog2_test #(parameter WIDTH = 8) (input logic [WIDTH-1:0] val);
+    function automatic integer reference_clog2(logic [WIDTH-1:0] n);
+        integer v;
+        reference_clog2 = 0;
+        if (n <= 1) return 0;
+        v = n - 1;
+        for (int i = 0; i < WIDTH; i++)
+            if (v[i]) reference_clog2 = i + 1;
+    endfunction
+
+    always_comb if (^val !== 'x) begin
+        assert($clog2(val) == reference_clog2(val));
+    end
+endmodule
+
+module clog2_8bit(input logic [7:0] val);
+    clog2_test #(.WIDTH(8)) t(.val(val));
+endmodule


### PR DESCRIPTION
Adds support for lowering the `$clog2` system function to RTLIL.
                                                                                                                                                                                                                                                       The implementation computes `$clog2(n)` as the MSB position of `n-1` plus 1, using a priority encoder built from a chain of multiplexers. The `n=0` edge case (where `n-1` wraps to all-ones) is handled by gating the output with `$reduce_bool(n)`.