### PR TITLE
[bug-fix] Fix big-endian unpacked array indexing

### DIFF
--- a/src/addressing.cc
+++ b/src/addressing.cc
@@ -26,9 +26,12 @@ void AddressingResolver::interpret_index(RTLIL::SigSpec signal, int width_down, 
 	} else {
 		base_offset = range.right - width_up + 1;
 
-		// We might want some other handling of big-endian
-		// indexing.
-		raw_signal = netlist.Not(signal);
+		// Sign-extend signal by one bit before inverting. This correctly
+		// maps big-endian index i to physical position (range.right - i):
+		//   Not(sign_ext(i)) + (range.right + 1) == (-i - 1) + (range.right + 1) == range.right - i.
+		// Sign-extension (not zero-extension) is required so that the identity
+		// holds for negative indices (e.g. logic [-7:-2]).
+		raw_signal = netlist.Not(RTLIL::SigSpec({signal.msb(), signal}));
 		base_offset += 1;
 	}
 }
@@ -38,6 +41,12 @@ AddressingResolver::AddressingResolver(EvalContext &eval, const ast::ElementSele
 {
 	require(sel, sel.value().type->hasFixedRange());
 	range = sel.value().type->getFixedRange();
+	// For unpacked arrays, elements are stored sequentially by logical index
+	// regardless of the declared range direction.  Normalise big-endian ranges
+	// to little-endian so that interpret_index maps element[i] directly to
+	// physical position (i - range.lower()), consistent with the memory-inferred path.
+	if (sel.value().type->isUnpackedArray() && !range.isLittleEndian())
+		range = {(int32_t)range.upper(), (int32_t)range.lower()};
 	interpret_index(eval.eval_signed(sel.selector()));
 
 	stride = sel.type->getBitstreamWidth();
@@ -48,6 +57,10 @@ AddressingResolver::AddressingResolver(EvalContext &eval, const ast::RangeSelect
 {
 	require(sel, sel.value().type->hasFixedRange());
 	range = sel.value().type->getFixedRange();
+	// For unpacked arrays, normalise big-endian ranges to little-endian
+	// so that element indexing is consistent with the memory-inferred path.
+	if (sel.value().type->isUnpackedArray() && !range.isLittleEndian())
+		range = {(int32_t)range.upper(), (int32_t)range.lower()};
 
 	switch (sel.getSelectionKind()) {
 	case ast::RangeSelectionKind::Simple: {

--- a/src/procedural.cc
+++ b/src/procedural.cc
@@ -270,11 +270,10 @@ void ProceduralContext::update_variable_state(slang::SourceLocation loc, Variabl
 				}
 				const ast::Symbol &symbol = *chunk.variable.get_symbol();
 				if (netlist.is_inferred_memory(symbol)) {
-					bool big_endian = !symbol.as<ast::ValueSymbol>()
-											   .getType()
-											   .getFixedRange()
-											   .isLittleEndian();
-					netlist.add_memory_init(netlist.id(symbol), chunk.base, big_endian,
+					// convert_const always stores element[i] at physical position
+					// (i - range.lower()), regardless of range direction, so the
+					// data is already in the correct word order.
+					netlist.add_memory_init(netlist.id(symbol), chunk.base, false,
 							rvalue.extract((int)base, (int)size).as_const());
 				}
 			} break;
@@ -450,8 +449,16 @@ void ProceduralContext::assign_rvalue(
 		// break down into individual assignments
 		auto &pattern_lexpr = raw_lexpr->as<ast::SimpleAssignmentPatternExpression>();
 
+		// Bits are extracted top-down (highest first).  For BE unpacked arrays
+		// the element with the highest logical index sits at the top bits
+		// (see EvalContext::operator() SimpleAssignmentPattern handling), so
+		// we need to visit elements in reverse declaration order so that each
+		// element is matched with the correct slice of rvalue.
+		bool be_unpacked = raw_lexpr->type->isUnpackedArray() &&
+				!raw_lexpr->type->getFixedRange().isLittleEndian();
+
 		int nbits_remaining = rvalue.size();
-		for (auto el : pattern_lexpr.elements()) {
+		auto do_elem = [&](const ast::Expression *el) {
 			log_assert(el->kind == ast::ExpressionKind::Assignment);
 			auto &inner_assign = el->as<ast::AssignmentExpression>();
 
@@ -467,6 +474,15 @@ void ProceduralContext::assign_rvalue(
 			nbits_remaining -= relem_width;
 
 			assign_rvalue(inner_assign, eval.apply_nested_conversion(inner_assign.right(), relem));
+		};
+
+		auto elems = pattern_lexpr.elements();
+		if (be_unpacked) {
+			for (auto it = elems.rbegin(); it != elems.rend(); it++)
+				do_elem(*it);
+		} else {
+			for (auto el : elems)
+				do_elem(el);
 		}
 
 		log_assert(nbits_remaining == 0);

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -180,7 +180,8 @@ static const RTLIL::Const convert_svint(const slang::SVInt &svint)
 }
 
 const std::optional<RTLIL::Const> NetlistContext::convert_const(const slang::ConstantValue &constval,
-																slang::SourceLocation loc)
+																slang::SourceLocation loc,
+																const ast::Type *type)
 {
 	if (constval.bad()) {
 		// no diagnostic in this case as we assume one has been raised upstream
@@ -211,13 +212,31 @@ const std::optional<RTLIL::Const> NetlistContext::convert_const(const slang::Con
 		std::vector<RTLIL::State> bits;
 		bits.reserve(constval.getBitstreamWidth());
 
+		const ast::Type *elem_type = (type && type->isUnpackedArray()) ?
+				type->getArrayElementType() : nullptr;
+		// For LE unpacked arrays slang's elements() declaration order has the
+		// highest-index element first, so reversing puts element[0] at the LSB,
+		// matching AddressingResolver's physical layout (element i at position i).
+		// For BE unpacked arrays slang's elements() declaration order has the
+		// lowest-index element first; reversing would put element[max] at LSB.
+		// Since AddressingResolver normalises BE to LE, element[0] must still be
+		// at the LSB, so we iterate forward (no reversal) for BE arrays.
+		bool be_unpacked = type && type->isUnpackedArray() &&
+				!type->getFixedRange().isLittleEndian();
 		auto elems = constval.elements();
-		for (auto it = elems.rbegin(); it != elems.rend(); it++) {
-			if (auto piece = convert_const(*it, loc)) {
-				bits.insert(bits.end(), piece->begin(), piece->end());	
-			} else {
-				return {};
+		auto convert_elem = [&](const slang::ConstantValue &elem) -> bool {
+			if (auto piece = convert_const(elem, loc, elem_type)) {
+				bits.insert(bits.end(), piece->begin(), piece->end());
+				return true;
 			}
+			return false;
+		};
+		if (be_unpacked) {
+			for (auto it = elems.begin(); it != elems.end(); it++)
+				if (!convert_elem(*it)) return {};
+		} else {
+			for (auto it = elems.rbegin(); it != elems.rend(); it++)
+				if (!convert_elem(*it)) return {};
 		}
 
 		log_assert(bits.size() == constval.getBitstreamWidth());
@@ -864,7 +883,7 @@ RTLIL::SigSpec EvalContext::operator()(ast::Expression const &expr)
 			expr.kind == ast::ExpressionKind::StringLiteral) {
 		auto const_result = expr.eval(this->const_);
 		if (const_result) {
-			auto converted = netlist.convert_const(const_result, expr.sourceRange.start());
+			auto converted = netlist.convert_const(const_result, expr.sourceRange.start(), expr.type);
 			if (converted) {
 				ret = *converted;
 				goto done;
@@ -1179,8 +1198,22 @@ RTLIL::SigSpec EvalContext::operator()(ast::Expression const &expr)
 			auto &pattern_expr = static_cast<const ast::AssignmentPatternExpressionBase&>(expr);
 
 			ret = {};
-			for (auto elem : pattern_expr.elements())
-				ret = {ret, (*this)(*elem)};
+			// SigSpec({a, b}) places 'b' at the lowest bits (initializer_list ctor
+			// processes in reverse).  For LE unpacked arrays the declaration order
+			// already puts high indices first so the last-appended low-index element
+			// ends up at the lowest bits - matching AddressingResolver's LE-normalised
+			// addressing.  For BE unpacked arrays (e.g. [0:3]) the declaration order
+			// puts low indices first, so the last-appended high-index element would end
+			// up at the lowest bits - reversed relative to LE-normalised addressing.
+			// Iterating in reverse for BE arrays fixes this.
+			if (expr.type->isUnpackedArray() && !expr.type->getFixedRange().isLittleEndian()) {
+				auto elems = pattern_expr.elements();
+				for (auto it = elems.rbegin(); it != elems.rend(); it++)
+					ret = {ret, (*this)(**it)};
+			} else {
+				for (auto elem : pattern_expr.elements())
+					ret = {ret, (*this)(*elem)};
+			}
 			ret = ret.repeat(repl_count);
 		}
 		break;

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -562,7 +562,7 @@ struct NetlistContext : RTLILBuilder, public DiagnosticIssuer {
 	void register_driven(const ast::Symbol &symbol);
 	void add_continuous_driver(VariableBits lhs, RTLIL::SigSpec rhs);
 
-	const std::optional<RTLIL::Const> convert_const(const slang::ConstantValue &constval, slang::SourceLocation loc);
+	const std::optional<RTLIL::Const> convert_const(const slang::ConstantValue &constval, slang::SourceLocation loc, const ast::Type *type = nullptr);
 };
 
 // slang_frontend.cc

--- a/tests/unit/bitsel.sv
+++ b/tests/unit/bitsel.sv
@@ -70,3 +70,24 @@ module test_bitsel07(data, sel);
 	input signed [4:0] sel;
 	base #(.MSB(-2), .LSB(-7)) t(.*);
 endmodule
+
+// BE with negative indices: sign-extension fix in interpret_index
+module test_bitsel08(data, sel);
+	input [-7:-2] data;
+	input signed [4:0] sel;
+	base #(.MSB(-7), .LSB(-2)) t(.*);
+endmodule
+
+// BE spanning negative and positive indices
+module test_bitsel09(data, sel);
+	input [-3:4] data;
+	input signed [4:0] sel;
+	base #(.MSB(-3), .LSB(4)) t(.*);
+endmodule
+
+// LE spanning negative and positive indices (mirror of test_bitsel09)
+module test_bitsel10(data, sel);
+	input [4:-3] data;
+	input signed [4:0] sel;
+	base #(.MSB(4), .LSB(-3)) t(.*);
+endmodule

--- a/tests/unit/partsel_down.sv
+++ b/tests/unit/partsel_down.sv
@@ -128,3 +128,17 @@ module test_partsel_down10(i1, i2, sel);
 	input [2:0] sel;
 	base2 #(.MSB(2), .LSB(7)) t(.*);
 endmodule
+
+// BE range with all-negative indices: sign-extension fix
+module test_partsel_down11(data, sel);
+	input [-7:-2] data;
+	input [2:0] sel;
+	base #(.MSB(-7), .LSB(-2)) t(.*);
+endmodule
+
+module test_partsel_down12(i1, i2, sel);
+	input [-7:-2] i1;
+	input [1:0] i2;
+	input [2:0] sel;
+	base2 #(.MSB(-7), .LSB(-2)) t(.*);
+endmodule

--- a/tests/unit/partsel_up.sv
+++ b/tests/unit/partsel_up.sv
@@ -123,3 +123,17 @@ module test_partsel_up10(i1, i2, sel);
 	input [2:0] sel;
 	base2 #(.MSB(2), .LSB(7)) t(.*);
 endmodule
+
+// BE range with all-negative indices: sign-extension fix
+module test_partsel_up11(data, sel);
+	input [-7:-2] data;
+	input [2:0] sel;
+	base #(.MSB(-7), .LSB(-2)) t(.*);
+endmodule
+
+module test_partsel_up12(i1, i2, sel);
+	input [-7:-2] i1;
+	input [1:0] i2;
+	input [2:0] sel;
+	base2 #(.MSB(-7), .LSB(-2)) t(.*);
+endmodule

--- a/tests/various/be_unpacked_array.ys
+++ b/tests/various/be_unpacked_array.ys
@@ -1,0 +1,185 @@
+# Test big-endian unpacked arrays ([0:N] range) are addressed correctly.
+#
+# With --no-implicit-memories the array goes through AddressingResolver instead
+# of the $mem path.  A bug caused the resolver to reverse the index for BE
+# unpacked arrays (as if they were packed BE vectors), making arr[i] access
+# element (range.right - i) instead of element i.
+
+# [0:3] and [3:0] unpacked arrays must be equivalent under --no-implicit-memories.
+# Uses equiv_make/induct so shared state is matched and proof is fast.
+design -reset
+read_slang --no-implicit-memories <<EOF
+module be_top(input clk, input [1:0] addr, input din, output dout);
+    reg arr [0:3];
+    always @(posedge clk)
+        arr[addr] <= din;
+    assign dout = arr[addr];
+endmodule
+EOF
+proc; opt_clean
+
+read_slang --no-implicit-memories <<EOF
+module le_top(input clk, input [1:0] addr, input din, output dout);
+    reg arr [3:0];
+    always @(posedge clk)
+        arr[addr] <= din;
+    assign dout = arr[addr];
+endmodule
+EOF
+proc; opt_clean
+
+equiv_make le_top be_top equiv_top
+equiv_induct equiv_top
+equiv_status -assert
+
+# Same equivalence must hold with the default (memory-inferred) path.
+design -reset
+read_slang <<EOF
+module be_top(input clk, input [1:0] addr, input din, output dout);
+    reg arr [0:3];
+    always @(posedge clk)
+        arr[addr] <= din;
+    assign dout = arr[addr];
+endmodule
+EOF
+proc; memory; memory_map; opt_clean
+
+read_slang <<EOF
+module le_top(input clk, input [1:0] addr, input din, output dout);
+    reg arr [3:0];
+    always @(posedge clk)
+        arr[addr] <= din;
+    assign dout = arr[addr];
+endmodule
+EOF
+proc; memory; memory_map; opt_clean
+
+equiv_make le_top be_top equiv_top
+equiv_induct equiv_top
+equiv_status -assert
+
+# BE packed vector [0:3]: dynamic bit-select must return the correct bit.
+# v[addr] on logic [0:3] should equal v_le[3-addr] of its LE mirror.
+# Tests the zero-extension fix in interpret_index.
+design -reset
+read_slang <<EOF
+module top(input [1:0] addr, input [0:3] v,
+           output bit_be, output bit_le);
+    assign bit_be = v[addr];
+    logic [3:0] v_le;
+    assign v_le = {v[0], v[1], v[2], v[3]};
+    assign bit_le = v_le[3 - addr];
+    always_comb
+        assert(bit_be === bit_le);
+endmodule
+EOF
+prep
+chformal -lower
+sat -verify -enable_undef -prove-asserts
+
+# BE vs LE unpacked array with non-zero lower bound: [2:5] vs [5:2].
+# Both arrays must return the same element for the same logical index.
+design -reset
+read_slang --no-implicit-memories <<EOF
+module be_top(input clk, input [1:0] idx, input din, output dout);
+    reg arr [2:5];
+    always @(posedge clk)
+        arr[idx + 2] <= din;
+    assign dout = arr[idx + 2];
+endmodule
+EOF
+proc; opt_clean
+
+read_slang --no-implicit-memories <<EOF
+module le_top(input clk, input [1:0] idx, input din, output dout);
+    reg arr [5:2];
+    always @(posedge clk)
+        arr[idx + 2] <= din;
+    assign dout = arr[idx + 2];
+endmodule
+EOF
+proc; opt_clean
+
+equiv_make le_top be_top equiv_top
+equiv_induct equiv_top
+equiv_status -assert
+
+# Same equivalence via default (memory-inferred) path.
+design -reset
+read_slang <<EOF
+module be_top(input clk, input [1:0] idx, input din, output dout);
+    reg arr [2:5];
+    always @(posedge clk)
+        arr[idx + 2] <= din;
+    assign dout = arr[idx + 2];
+endmodule
+EOF
+proc; memory; memory_map; opt_clean
+
+read_slang <<EOF
+module le_top(input clk, input [1:0] idx, input din, output dout);
+    reg arr [5:2];
+    always @(posedge clk)
+        arr[idx + 2] <= din;
+    assign dout = arr[idx + 2];
+endmodule
+EOF
+proc; memory; memory_map; opt_clean
+
+equiv_make le_top be_top equiv_top
+equiv_induct equiv_top
+equiv_status -assert
+
+# BE vs LE unpacked array with multi-bit (8-bit) elements.
+# [0:3] vs [3:0] must produce identical read/write behaviour.
+design -reset
+read_slang --no-implicit-memories <<EOF
+module be_top(input clk, input [1:0] addr, input [7:0] din, output [7:0] dout);
+    reg [7:0] arr [0:3];
+    always @(posedge clk)
+        arr[addr] <= din;
+    assign dout = arr[addr];
+endmodule
+EOF
+proc; opt_clean
+
+read_slang --no-implicit-memories <<EOF
+module le_top(input clk, input [1:0] addr, input [7:0] din, output [7:0] dout);
+    reg [7:0] arr [3:0];
+    always @(posedge clk)
+        arr[addr] <= din;
+    assign dout = arr[addr];
+endmodule
+EOF
+proc; opt_clean
+
+equiv_make le_top be_top equiv_top
+equiv_induct equiv_top
+equiv_status -assert
+
+# BE unpacked array with negative lower bound: [0:-3] vs [-3:0].
+# Uses --no-implicit-memories path.
+design -reset
+read_slang --no-implicit-memories <<EOF
+module be_top(input clk, input [1:0] addr, input din, output dout);
+    reg arr [0:-3];
+    always @(posedge clk)
+        arr[addr - 3] <= din;
+    assign dout = arr[addr - 3];
+endmodule
+EOF
+proc; opt_clean
+
+read_slang --no-implicit-memories <<EOF
+module le_top(input clk, input [1:0] addr, input din, output dout);
+    reg arr [-3:0];
+    always @(posedge clk)
+        arr[addr - 3] <= din;
+    assign dout = arr[addr - 3];
+endmodule
+EOF
+proc; opt_clean
+
+equiv_make le_top be_top equiv_top
+equiv_induct equiv_top
+equiv_status -assert

--- a/tests/various/meminit.ys
+++ b/tests/various/meminit.ys
@@ -110,3 +110,51 @@ memory_collect
 select -assert-count 1 t:$mem_v2
 memory_map
 sat -verify -enable_undef -prove-asserts
+
+# BE unpacked array [0:1]: constant aggregate init must index correctly.
+# Without --no-implicit-memories x is a $mem ROM, y is synthesised as flops.
+# Both must agree on which element is at each index.
+design -reset
+read_slang --no-implicit-memories <<EOF2
+module top();
+	(* rom_block *)
+	reg [3:0] x[0:1];
+	reg [3:0] y[0:1];
+
+	initial begin
+		x = '{7, 1};
+		y = '{7, 1};
+	end
+
+	always_comb
+		assert(x[0] === y[0] && x[1] === y[1]);
+endmodule
+EOF2
+chformal -lower
+memory_collect
+select -assert-count 1 t:$mem_v2
+memory_map
+sat -verify -enable_undef -prove-asserts
+
+# BE unpacked array with non-zero lower bound [2:4].
+design -reset
+read_slang --no-implicit-memories <<EOF2
+module top();
+	(* rom_block *)
+	reg [3:0] x[2:4];
+	reg [3:0] y[2:4];
+
+	initial begin
+		x = '{5, 3, 9};
+		y = '{5, 3, 9};
+	end
+
+	always_comb
+		assert(x[2] === y[2] && x[3] === y[3] && x[4] === y[4]);
+endmodule
+EOF2
+chformal -lower
+memory_collect
+select -assert-count 1 t:$mem_v2
+memory_map
+sat -verify -enable_undef -prove-asserts


### PR DESCRIPTION
This patch corrects four related bugs in how big-endian (BE) ranges are handled throughout the frontend.

Problem:
SystemVerilog allows both big-endian ([0:N]) and little-endian ([N:0]) range declarations for packed vectors and unpacked arrays. Several code paths in the frontend mishandled BE ranges, producing wrong synthesis output:

1. AddressingResolver treated BE unpacked arrays like BE packed vectors. Unpacked arrays are always stored sequentially by logical index regardless of declaration order, but interpret_index was applying the bit-reversal transformation intended for packed BE vectors, making arr[i] silently access the wrong element under `--no-implicit-memories`.
2. `interpret_index` used zero-extension before NOT, breaking negative indices. For packed vectors with negative index ranges (e.g. `logic [-7:-2]`), the zero-extended value is large and positive, and Not produces a wildly wrong shift amount, yielding x for all in-range accesses.
3. Constant aggregate evaluation iterated BE unpacked arrays in the wrong order. `convert_const` used rbegin for all unpacked arrays. After normalising BE ranges to LE in `AddressingResolver`, element `[lower]` must be at the LSB, but reversing a BE array's declaration order (which already starts at the lowest index) puts the highest-index element there instead.
4. `SimpleAssignmentPattern` on both RHS and LHS handled BE arrays incorrectly. The synthesis-path evaluator and the procedural LHS decomposer both iterated elements in the wrong order for BE unpacked arrays, causing mismatches between constant folding and synthesis results.

Fix:
  - `src/addressing.cc`: Normalise BE unpacked array ranges to LE in both `ElementSelectExpression` and `RangeSelectExpression` constructors, so `interpret_index` always sees a LE range for unpacked arrays. Replace zero-extension with sign-extension in `interpret_index`s BE branch (1{signal.msb(), signal}` instead of `{S0, signal}`), making the formula correct for all signed index values.
  - `src/slang_frontend.cc`: Add an optional type parameter to `convert_const` - use forward element iteration for BE unpacked arrays so the physical layout matches the LE-normalised addressing. Reverse `SimpleAssignmentPattern` element iteration for BE unpacked arrays on the RHS synthesis path. 
  - `src/procedural.cc`: Reverse `SimpleAssignmentPattern` element iteration for BE unpacked arrays on the LHS decomposition path. Remove the now-redundant `big_endian`
  -  flag from `add_memory_init` - `convert_const` already produces element `[i]` at physical position (`i` − lower) for all arrays.