### PR TITLE
Fix interface output port undriven detection in nested --keep-hierarchy

### DIFF
--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -2023,6 +2023,8 @@ public:
 							RTLIL::IdString port_name = port_sig.as_wire()->name;
 							if (netlist.scopes_remap.count(&modport)) {
 								cell->setPort(port_name, netlist.wire(port));
+								if (port.direction == ast::ArgumentDirection::Out || port.direction == ast::ArgumentDirection::InOut)
+									netlist.register_driven(port);
 							} else {
 								cell->setPort(port_name, netlist.wire(*port.internalSymbol));
 								if (port.direction == ast::ArgumentDirection::Out || port.direction == ast::ArgumentDirection::InOut)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ set(ALL_TESTS
     various/issue227.ys
     various/issue240.ys
     various/issue266.ys
+    various/issue300.ys
     various/issue50.ys
     various/mem_inference.ys
     various/meminit.ys

--- a/tests/various/issue300.ys
+++ b/tests/various/issue300.ys
@@ -1,0 +1,31 @@
+read_slang --std 1800-2017 --keep-hierarchy <<EOF
+interface foobar;
+  logic in1;
+  logic out1;
+  modport port (
+    input in1,
+    output out1
+  );
+endinterface
+
+module bar (foobar.port ports);
+  assign ports.out1 = ports.in1;
+endmodule
+
+module foo (foobar.port ports);
+  bar inst2 (.ports(ports));
+endmodule
+
+module top (input in1, output out1);
+  foobar _foobar();
+  assign _foobar.in1 = in1;
+  assign out1 = _foobar.out1;
+  foo inst1 (.ports(_foobar));
+  always_comb assert(out1 === in1);
+endmodule
+EOF
+hierarchy -top top
+check -assert
+flatten
+chformal -lower
+sat -verify -enable_undef -prove-asserts


### PR DESCRIPTION
When a non-dissolved module (`foo`) contained another non-dissolved instance (`inst2`) driving an interface output port, `register_driven` was not called for that port. As a result, `finalize_variable_initialization` connected the output to `X`, and subsequent opt passes removed the driving instance entirely.
                                                                                                                                                                                                                                                      
   
**Fix**: call `netlist.register_driven(port)` in the scopes_remap branch for Out/InOut modport ports.