### PR TITLE
 Support assignment patterns on the LHS of port connections

### DIFF
--- a/src/lvalue.cc
+++ b/src/lvalue.cc
@@ -7,7 +7,6 @@
 #include "slang/ast/expressions/ConversionExpression.h"
 #include "slang/ast/expressions/MiscExpressions.h"
 #include "slang/ast/expressions/OperatorExpressions.h"
-#include "slang/ast/expressions/AssignmentExpressions.h"
 #include "slang/ast/expressions/SelectExpressions.h"
 #include "slang/ast/symbols/MemberSymbols.h"
 #include "slang/ast/symbols/VariableSymbols.h"
@@ -111,20 +110,6 @@ std::optional<LValue> LValue::analyze(
 				return std::nullopt;
 			elements.push_back(std::move(*element_lv));
 		}
-		return LValue::concatenation(std::move(elements));
-	}
-	case ast::ExpressionKind::SimpleAssignmentPattern: {
-		std::vector<LValue> elements;
-		const auto &pattern = expr.as<ast::SimpleAssignmentPatternExpression>();
-		for (auto element : pattern.elements()) {
-			ast_invariant(expr, element->kind == ast::ExpressionKind::Assignment);
-			auto &assign = element->as<ast::AssignmentExpression>();
-			auto element_lv = analyze(context, assign.left(), silent);
-			if (!element_lv)
-				return std::nullopt;
-			elements.push_back(std::move(*element_lv));
-		}
-
 		return LValue::concatenation(std::move(elements));
 	}
 	case ast::ExpressionKind::MemberAccess: {

--- a/src/lvalue.cc
+++ b/src/lvalue.cc
@@ -7,6 +7,7 @@
 #include "slang/ast/expressions/ConversionExpression.h"
 #include "slang/ast/expressions/MiscExpressions.h"
 #include "slang/ast/expressions/OperatorExpressions.h"
+#include "slang/ast/expressions/AssignmentExpressions.h"
 #include "slang/ast/expressions/SelectExpressions.h"
 #include "slang/ast/symbols/MemberSymbols.h"
 #include "slang/ast/symbols/VariableSymbols.h"
@@ -110,6 +111,20 @@ std::optional<LValue> LValue::analyze(
 				return std::nullopt;
 			elements.push_back(std::move(*element_lv));
 		}
+		return LValue::concatenation(std::move(elements));
+	}
+	case ast::ExpressionKind::SimpleAssignmentPattern: {
+		std::vector<LValue> elements;
+		const auto &pattern = expr.as<ast::SimpleAssignmentPatternExpression>();
+		for (auto element : pattern.elements()) {
+			ast_invariant(expr, element->kind == ast::ExpressionKind::Assignment);
+			auto &assign = element->as<ast::AssignmentExpression>();
+			auto element_lv = analyze(context, assign.left(), silent);
+			if (!element_lv)
+				return std::nullopt;
+			elements.push_back(std::move(*element_lv));
+		}
+
 		return LValue::concatenation(std::move(elements));
 	}
 	case ast::ExpressionKind::MemberAccess: {

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -2077,6 +2077,19 @@ public:
 			return;
 		}
 
+		if (ast::SimpleAssignmentPatternExpression::isKind(expr.left().kind)) {
+			auto &pattern_lexpr = expr.left().as<ast::SimpleAssignmentPatternExpression>();
+			RTLIL::SigSpec link;
+			auto els = pattern_lexpr.elements();
+			for (auto it = els.rbegin(); it != els.rend(); it++) {
+				ast_invariant(**it, (*it)->kind == ast::ExpressionKind::Assignment);
+				auto &inner_assign = (*it)->as<ast::AssignmentExpression>();
+				link.append(netlist.eval.connection_lhs(inner_assign));
+			}
+			netlist.connect(link, rvalue);
+			return;
+		}
+
 		netlist.add_continuous_driver(netlist.eval.lhs(expr.left()), rvalue);
 	}
 

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -624,23 +624,35 @@ void NetlistContext::add_continuous_driver(VariableBits lhs, RTLIL::SigSpec rhs)
 RTLIL::SigSpec EvalContext::connection_lhs(ast::AssignmentExpression const &assign)
 {
 	ast_invariant(assign, !assign.timingControl);
-	const ast::Expression *rsymbol = &assign.right();
-	VariableBits vbits = lhs(assign.left());
+	const ast::Expression *rexpr = &assign.right();
 
-	if (rsymbol->kind == ast::ExpressionKind::EmptyArgument &&
+	if (ast::SimpleAssignmentPatternExpression::isKind(assign.left().kind)) {
+		auto &pattern_lexpr = assign.left().as<ast::SimpleAssignmentPatternExpression>();
+		RTLIL::SigSpec link;
+		auto els = pattern_lexpr.elements();
+		for (auto it = els.rbegin(); it != els.rend(); it++) {
+			ast_invariant(**it, (*it)->kind == ast::ExpressionKind::Assignment);
+			auto &inner_assign = (*it)->as<ast::AssignmentExpression>();
+			link.append(connection_lhs(inner_assign));
+		}
+		return link;
+	}
+
+	VariableBits vbits = lhs(assign.left());
+	if (rexpr->kind == ast::ExpressionKind::EmptyArgument &&
 			!vbits.has_special_nets()) {
 		// early path
 		netlist.register_driven(vbits);
 		return netlist.convert_static(vbits);
 	}
 
-	while (rsymbol->kind == ast::ExpressionKind::Conversion)
-		rsymbol = &rsymbol->as<ast::ConversionExpression>().operand();
-	ast_invariant(assign, rsymbol->kind == ast::ExpressionKind::EmptyArgument);
-	ast_invariant(assign, rsymbol->type->isBitstreamType());
+	while (rexpr->kind == ast::ExpressionKind::Conversion)
+		rexpr = &rexpr->as<ast::ConversionExpression>().operand();
+	ast_invariant(assign, rexpr->kind == ast::ExpressionKind::EmptyArgument);
+	ast_invariant(assign, rexpr->type->isBitstreamType());
 
 	RTLIL::SigSpec link = netlist.add_placeholder_signal(
-								rsymbol->type->getBitstreamWidth());
+								rexpr->type->getBitstreamWidth());
 	netlist.add_continuous_driver(vbits,
 			apply_nested_conversion(assign.right(), link));
 	return link;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(ALL_TESTS
     unit/latch.ys
     unit/selftests.tcl
     various/assign_mixing.ys
+    various/assignment_pattern_lhs.ys
     various/bb_detect.ys
     various/blackbox_scenarios.ys
     various/bus_range.ys

--- a/tests/various/assignment_pattern_lhs.ys
+++ b/tests/various/assignment_pattern_lhs.ys
@@ -1,0 +1,21 @@
+read_slang <<EOF
+module test (
+  input  logic a_i[2],
+  output logic y_o[2]
+);
+  inner i_inner (
+    .a_i ('{a_i[0], a_i[1]}),
+    .y_o ('{y_o[0], y_o[1]})
+  );
+endmodule
+
+module inner (
+  input  logic a_i[2],
+  output logic y_o[2]
+);
+  assign y_o[0] = a_i[1];
+  assign y_o[1] = a_i[0];
+endmodule
+EOF
+
+check -assert

--- a/tests/various/assignment_pattern_lhs.ys
+++ b/tests/various/assignment_pattern_lhs.ys
@@ -1,21 +1,39 @@
 read_slang <<EOF
-module test (
-  input  logic a_i[2],
-  output logic y_o[2]
+typedef struct packed {
+  logic a;
+  logic b;
+} foo_t;
+typedef struct packed {
+  foo_t foo;
+  logic c;
+} bar_t;
+
+module feedthrough (
+  input bar_t a_i[2],
+  output bar_t y_o[2]
 );
-  inner i_inner (
-    .a_i ('{a_i[0], a_i[1]}),
-    .y_o ('{y_o[0], y_o[1]})
-  );
+  assign y_o = a_i;
 endmodule
 
 module inner (
-  input  logic a_i[2],
-  output logic y_o[2]
+  input bar_t a_i[2]
 );
-  assign y_o[0] = a_i[1];
-  assign y_o[1] = a_i[0];
+  logic [1:0] a1, b1, c1, a2, b2, c2;
+  logic [1:0] ga1, gb1, gc1, ga2, gb2, gc2;
+  feedthrough f(a_i,
+    '{'{'{a1, b1}, c1}, '{'{a2, b2}, c2}});
+  always_comb
+    '{'{'{ga1, gb1}, gc1}, '{'{ga2, gb2}, gc2}} = a_i;
+
+  always_comb begin
+    assert(a1 === ga1);
+    assert(b1 === gb1);
+    assert(c1 === gc1);
+    assert(a2 === ga2);
+    assert(b2 === gb2);
+    assert(c2 === gc2);
+  end
 endmodule
 EOF
-
-check -assert
+chformal -lower
+sat -show-all -verify -enable_undef -prove-asserts

--- a/tests/various/assignment_pattern_lhs.ys
+++ b/tests/various/assignment_pattern_lhs.ys
@@ -37,3 +37,36 @@ endmodule
 EOF
 chformal -lower
 sat -show-all -verify -enable_undef -prove-asserts
+
+design -reset
+read_slang <<EOF
+typedef struct packed {
+  logic a;
+  logic b;
+} foo_t;
+typedef struct packed {
+  foo_t foo;
+  logic c;
+} bar_t;
+
+module inner (
+  input bar_t a_i[2]
+);
+  logic [1:0] a1, b1, c1, a2, b2, c2;
+  logic [1:0] ga1, gb1, gc1, ga2, gb2, gc2;
+  assign '{'{'{a1, b1}, c1}, '{'{a2, b2}, c2}} = a_i;
+  always_comb
+    '{'{'{ga1, gb1}, gc1}, '{'{ga2, gb2}, gc2}} = a_i;
+
+  always_comb begin
+    assert(a1 === ga1);
+    assert(b1 === gb1);
+    assert(c1 === gc1);
+    assert(a2 === ga2);
+    assert(b2 === gb2);
+    assert(c2 === gc2);
+  end
+endmodule
+EOF
+chformal -lower
+sat -show-all -verify -enable_undef -prove-asserts


### PR DESCRIPTION
The test added failed before but is properly handled now.

Each port connection to an input or output port is a continuous assignment from source to sink (23.3.3). Simple assignment patterns on the left-hand side of such assignments were rejected, e.g.:
    .y_o ('{y_o[0], y_o[1]})

Lower them element-wise to concatenation LValues, matching the existing procedural handling.