### PR TITLE
Add configurable ff naming schemes

### DIFF
--- a/src/builder.cc
+++ b/src/builder.cc
@@ -24,7 +24,9 @@ static IdString id(std::string_view sv)
 #else
 static IdString id(std::string_view sv)
 {
-	return sv;
+	if (sv.empty() || sv[0] == '$' || sv[0] == '\\')
+		return sv;
+	return RTLIL::escape_id(std::string(sv));
 }
 #endif
 

--- a/src/naming.cc
+++ b/src/naming.cc
@@ -81,7 +81,8 @@ std::vector<NamedChunk> generate_subfield_names(VariableChunk chunk, const ast::
 	return ret;
 }
 
-// Format one raw hierarchy or signal name into a friendly identifier
+// Format one raw hierarchy or signal name into an alphanumeric+underscore identifier fragment
+// Makes it easy to use and compose in Tcl-style contexts without escaping characters
 static std::string format_name_fragment(std::string_view raw)
 {
 	std::string ret;

--- a/src/naming.cc
+++ b/src/naming.cc
@@ -4,6 +4,8 @@
 // Copyright Martin Povišer <povik@cutebit.org>
 // Distributed under the terms of the ISC license, see LICENSE
 //
+#include <cctype>
+
 #include "slang/ast/symbols/VariableSymbols.h"
 #include "slang/ast/types/Type.h"
 
@@ -77,6 +79,110 @@ std::vector<NamedChunk> generate_subfield_names(VariableChunk chunk, const ast::
 	log_assert(sum == chunk.bitwidth());
 
 	return ret;
+}
+
+// Format one raw hierarchy or signal name into a friendly identifier
+static std::string format_name_fragment(std::string_view raw)
+{
+	std::string ret;
+	ret.reserve(raw.size() + 8);
+
+	auto push_sep = [&]() {
+		if (!ret.empty() && ret.back() != '_')
+			ret.push_back('_');
+	};
+
+	for (size_t i = 0; i < raw.size(); i++) {
+		unsigned char ch = raw[i];
+
+		// Alphanumeric and underscore characters are kept as-is
+		if (std::isalnum(ch) || ch == '_') {
+			ret.push_back(ch);
+			continue;
+		}
+
+		// Flatten dotted hierarchy and subfields into underscores
+		if (ch == '.') {
+			push_sep();
+			continue;
+		}
+
+		// `$<n>` comes from unnamed scopes; keep it distinct from `[n]`, which is an array index.
+		if (ch == '$' && i + 1 < raw.size() && std::isdigit((unsigned char)raw[i + 1])) {
+			if (ret.empty() || ret.back() != '_')
+				ret.push_back('_');
+			ret.push_back('_');
+			i++;
+			while (i < raw.size() && std::isdigit((unsigned char)raw[i])) {
+				ret.push_back(raw[i]);
+				i++;
+			}
+			i--;
+			continue;
+		}
+
+		// Add packed and unpacked indices as explicit suffixes
+		if (ch == '[') {
+			push_sep();
+
+			std::string lhs_index;
+			size_t j = i + 1;
+			while (j < raw.size() && raw[j] != ']' && raw[j] != ':') {
+				lhs_index.push_back(raw[j]);
+				j++;
+			}
+			ret.append(lhs_index);
+
+			if (j < raw.size() && raw[j] == ':') {
+				// Keep multi-bit slices explicit so ranges remain readable
+				j++;
+				std::string rhs;
+				while (j < raw.size() && raw[j] != ']') {
+					rhs.push_back(raw[j]);
+					j++;
+				}
+
+				if (lhs_index != rhs) {
+					ret.append("downto");
+					ret.append(rhs);
+				}
+			}
+
+			while (j < raw.size() && raw[j] != ']')
+				j++;
+			i = j;
+			continue;
+		}
+
+		// Collapse any remaining symbols into a separator
+		push_sep();
+	}
+
+	while (!ret.empty() && ret.back() == '_')
+		ret.pop_back();
+
+	return ret;
+}
+
+// Format a scope path relative to another scope using the naming fragment rules above.
+std::string format_scope_name_fragment(const ast::Scope *relative_to, const ast::Scope *scope)
+{
+	return format_name_fragment(hierpath_relative_to(relative_to, scope));
+}
+
+// Format a signal path plus optional subfield or slice suffix into one name fragment.
+std::string format_signal_name_fragment(const ast::Scope *relative_to, const ast::ValueSymbol &symbol,
+		std::string_view suffix)
+{
+	auto *scope = symbol.getParentScope();
+	ast_invariant(symbol, scope != nullptr);
+
+	std::string raw = hierpath_relative_to(relative_to, scope);
+	if (!raw.empty())
+		raw.push_back('.');
+	raw.append(symbol.name);
+	raw.append(suffix);
+	return format_name_fragment(raw);
 }
 
 }; // namespace slang_frontend

--- a/src/naming.cc
+++ b/src/naming.cc
@@ -81,16 +81,21 @@ std::vector<NamedChunk> generate_subfield_names(VariableChunk chunk, const ast::
 	return ret;
 }
 
-// Format one raw hierarchy or signal name into an alphanumeric+underscore identifier fragment
-// Makes it easy to use and compose in Tcl-style contexts without escaping characters
-static std::string format_name_fragment(std::string_view raw)
+// Format one raw hierarchy or signal name into an alphanumeric / separator identifier fragment.
+// Makes it easy to use and compose in Tcl-style contexts without escaping characters.
+static std::string format_name_fragment(std::string_view raw, std::string_view sep)
 {
 	std::string ret;
 	ret.reserve(raw.size() + 8);
 
+	auto ends_with_sep = [&]() {
+		return !sep.empty() && ret.size() >= sep.size() &&
+			ret.compare(ret.size() - sep.size(), sep.size(), sep) == 0;
+	};
+
 	auto push_sep = [&]() {
-		if (!ret.empty() && ret.back() != '_')
-			ret.push_back('_');
+		if (!ret.empty() && !ends_with_sep())
+			ret.append(sep);
 	};
 
 	for (size_t i = 0; i < raw.size(); i++) {
@@ -110,9 +115,8 @@ static std::string format_name_fragment(std::string_view raw)
 
 		// `$<n>` comes from unnamed scopes; keep it distinct from `[n]`, which is an array index.
 		if (ch == '$' && i + 1 < raw.size() && std::isdigit((unsigned char)raw[i + 1])) {
-			if (ret.empty() || ret.back() != '_')
-				ret.push_back('_');
-			ret.push_back('_');
+			push_sep();
+			ret.append(sep);
 			i++;
 			while (i < raw.size() && std::isdigit((unsigned char)raw[i])) {
 				ret.push_back(raw[i]);
@@ -159,21 +163,22 @@ static std::string format_name_fragment(std::string_view raw)
 		push_sep();
 	}
 
-	while (!ret.empty() && ret.back() == '_')
-		ret.pop_back();
+	while (ends_with_sep())
+		ret.resize(ret.size() - sep.size());
 
 	return ret;
 }
 
 // Format a scope path relative to another scope using the naming fragment rules above.
-std::string format_scope_name_fragment(const ast::Scope *relative_to, const ast::Scope *scope)
+std::string format_scope_name_fragment(const ast::Scope *relative_to, const ast::Scope *scope,
+		std::string_view sep)
 {
-	return format_name_fragment(hierpath_relative_to(relative_to, scope));
+	return format_name_fragment(hierpath_relative_to(relative_to, scope), sep);
 }
 
 // Format a signal path plus optional subfield or slice suffix into one name fragment.
 std::string format_signal_name_fragment(const ast::Scope *relative_to, const ast::ValueSymbol &symbol,
-		std::string_view suffix)
+		std::string_view suffix, std::string_view sep)
 {
 	auto *scope = symbol.getParentScope();
 	ast_invariant(symbol, scope != nullptr);
@@ -183,7 +188,7 @@ std::string format_signal_name_fragment(const ast::Scope *relative_to, const ast
 		raw.push_back('.');
 	raw.append(symbol.name);
 	raw.append(suffix);
-	return format_name_fragment(raw);
+	return format_name_fragment(raw, sep);
 }
 
 }; // namespace slang_frontend

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -208,10 +208,6 @@ static std::string ff_naming_base_name_from_options(SynthesisSettings &settings,
 	std::string prefix = settings.ff_naming_prefix();
 	std::string suffix = settings.ff_naming_suffix();
 
-	std::string signal_name = format_signal_name_fragment(&netlist.realm, symbol, subfield_suffix);
-	auto *symbol_scope = symbol.getParentScope();
-	ast_invariant(symbol, symbol_scope != nullptr);
-	std::string local_signal_name = format_signal_name_fragment(symbol_scope, symbol, subfield_suffix);
 
 	// Avoid duplicating the configured suffix when the base name already ends in it
 	auto maybe_append_suffix = [&](std::string name) {
@@ -239,10 +235,15 @@ static std::string ff_naming_base_name_from_options(SynthesisSettings &settings,
 		return with_prefix(base_name);
 	}
 
+	std::string signal_name = format_signal_name_fragment(&netlist.realm, symbol, subfield_suffix);
+
 	if (mode == "signal")
 		return with_prefix(maybe_append_suffix(signal_name));
 	if (mode == "auto") {
 		if (block_symbol) {
+			auto *symbol_scope = symbol.getParentScope();
+			ast_invariant(symbol, symbol_scope != nullptr);
+			std::string local_signal_name = format_signal_name_fragment(symbol_scope, symbol, subfield_suffix);
 			std::string block_name = format_scope_name_fragment(&netlist.realm, block_symbol);
 			if (disambiguate_block_name)
 				return with_prefix(maybe_append_suffix(block_name + "_" + local_signal_name));

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -79,6 +79,14 @@ void SynthesisSettings::addOptions(slang::CommandLine &cmdLine) {
 			"--udp-handling", udp_handling, "Set the processing mode for user defined primitives."
 			" When set to 'blackboxes' the UDP is treated as a blackboxed instance."
 			" When set to 'error', an error is emitted if a UDP is encountered. By default, the frontend emits an error.");
+	cmdLine.add("--ff-naming", ff_naming,
+				"Set the naming scheme used for flip-flops inferred from always_ff blocks."
+				" Valid values: legacy, signal, auto."
+				" Note: 'auto' names are unstable and may change across versions.", "<mode>");
+	cmdLine.add("--ff-prefix", ff_prefix,
+				"Set the prefix prepended to inferred flip-flop names.", "<prefix>");
+	cmdLine.add("--ff-suffix", ff_suffix,
+				"Set the suffix appended to inferred flip-flop names.", "<suffix>");
 
 	// Deprecated section
 	cmdLine.add("--compat-mode", compat_mode,
@@ -163,6 +171,86 @@ static const RTLIL::IdString module_type_id(const ast::InstanceBodySymbol &sym)
 		return RTLIL::escape_id(std::string(sym.name));
 	else
 		return RTLIL::escape_id(std::string(sym.name) + "$" + instance);
+}
+
+// Return the pre-prefix flip-flop base name used by the legacy scheme
+static std::string ff_naming_legacy_signal_name(NetlistContext &netlist, const ast::ValueSymbol &symbol,
+		std::string_view suffix)
+{
+	return Yosys::stringf("%s%s",
+			RTLIL::unescape_id(netlist.id(symbol)).c_str(), std::string(suffix).c_str());
+}
+
+// Find the named block that `--ff-naming auto` should prefer, if there is one
+static const ast::StatementBlockSymbol *ff_naming_auto_block(const ast::StatementBlockSymbol *prologue_block,
+		const ast::Statement &sync_body)
+{
+	if (prologue_block && !prologue_block->name.empty())
+		return prologue_block;
+
+	if (sync_body.kind != ast::StatementKind::Block)
+		return nullptr;
+
+	auto &block = sync_body.as<ast::BlockStatement>();
+	ast_invariant(sync_body, block.blockKind == ast::StatementBlockKind::Sequential);
+	if (block.blockSymbol && !block.blockSymbol->name.empty())
+		return block.blockSymbol;
+
+	return nullptr;
+}
+
+// Build the final inferred flip-flop base name from the active ff naming options
+static std::string ff_naming_base_name_from_options(SynthesisSettings &settings, NetlistContext &netlist,
+		const ast::StatementBlockSymbol *block_symbol, bool disambiguate_block_name,
+		const ast::ValueSymbol &symbol, std::string_view subfield_suffix)
+{
+	auto mode = settings.ff_naming_mode();
+	std::string prefix = settings.ff_naming_prefix();
+	std::string suffix = settings.ff_naming_suffix();
+
+	std::string signal_name = format_signal_name_fragment(&netlist.realm, symbol, subfield_suffix);
+	auto *symbol_scope = symbol.getParentScope();
+	ast_invariant(symbol, symbol_scope != nullptr);
+	std::string local_signal_name = format_signal_name_fragment(symbol_scope, symbol, subfield_suffix);
+
+	// Avoid duplicating the configured suffix when the base name already ends in it
+	auto maybe_append_suffix = [&](std::string name) {
+		if (!suffix.empty() && name.size() >= suffix.size() &&
+				name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0)
+				return name;
+		return name + suffix;
+	};
+
+	auto make_public = [](std::string name) {
+		return std::string("\\") + name;
+	};
+
+	// Avoid duplicating the configured prefix when the base name already starts with it
+	auto with_prefix = [&](std::string name) {
+		if (!prefix.empty() && name.size() >= prefix.size() &&
+				name.compare(0, prefix.size(), prefix) == 0)
+			return make_public(name);
+		return make_public(prefix + name);
+	};
+
+	if (mode == "legacy") {
+		std::string base_name = ff_naming_legacy_signal_name(netlist, symbol, subfield_suffix);
+		base_name = maybe_append_suffix(base_name);
+		return with_prefix(base_name);
+	}
+
+	if (mode == "signal")
+		return with_prefix(maybe_append_suffix(signal_name));
+	if (mode == "auto") {
+		if (block_symbol) {
+			std::string block_name = format_scope_name_fragment(&netlist.realm, block_symbol);
+			if (disambiguate_block_name)
+				return with_prefix(maybe_append_suffix(block_name + "_" + local_signal_name));
+			return with_prefix(maybe_append_suffix(block_name));
+		}
+		return with_prefix(maybe_append_suffix(signal_name));
+	}
+	log_abort();
 }
 
 static const RTLIL::Const convert_svint(const slang::SVInt &svint)
@@ -1487,6 +1575,14 @@ public:
 
 			// FIXME: ignores variables not driven from the sync procedure
 			VariableBits driven = sync_procedure.all_driven();
+			const ast::StatementBlockSymbol *block_symbol = ff_naming_auto_block(prologue_block, sync_body);
+			int emitted_ff_names = 0;
+			for (VariableChunk driven_chunk : driven.chunks()) {
+				const ast::Type *type = &driven_chunk.variable.get_symbol()->getType();
+				emitted_ff_names += generate_subfield_names(driven_chunk, type).size();
+			}
+			bool disambiguate_block_name = emitted_ff_names > 1;
+
 			for (VariableChunk driven_chunk : driven.chunks()) {
 				const ast::Type *type = &driven_chunk.variable.get_symbol()->getType();
 				RTLIL::SigSpec assigned = sync_procedure.vstate.evaluate(netlist, driven_chunk);
@@ -1497,9 +1593,10 @@ public:
 				if (aloads.empty()) {
 
 					for (auto [named_chunk, name] : generate_subfield_names(driven_chunk, type)) {
-						log_assert(named_chunk.variable.get_symbol() != nullptr);
-						std::string base_name = Yosys::stringf("$driver$%s%s",
-							RTLIL::unescape_id(netlist.id(*named_chunk.variable.get_symbol())).c_str(), name.c_str());
+						auto *named_symbol = named_chunk.variable.get_symbol();
+						log_assert(named_symbol != nullptr);
+						std::string base_name = ff_naming_base_name_from_options(settings, netlist, block_symbol,
+								disambiguate_block_name, *named_symbol, name);
 
 						if (clock.edge == ast::EdgeKind::BothEdges) {
 							netlist.add_dual_edge_aldff(base_name,
@@ -1533,9 +1630,10 @@ public:
 					if (!aldff_q.empty()) {
 						for (auto driven_chunk2 : aldff_q.chunks())
 						for (auto [named_chunk, name] : generate_subfield_names(driven_chunk2, type)) {
-							log_assert(named_chunk.variable.get_symbol() != nullptr);
-							std::string base_name = Yosys::stringf("$driver$%s%s",
-								RTLIL::unescape_id(netlist.id(*named_chunk.variable.get_symbol())).c_str(), name.c_str());
+							auto *named_symbol = named_chunk.variable.get_symbol();
+							log_assert(named_symbol != nullptr);
+							std::string base_name = ff_naming_base_name_from_options(settings, netlist, block_symbol,
+									disambiguate_block_name, *named_symbol, name);
 
 							if (clock.edge == ast::EdgeKind::BothEdges) {
 								netlist.add_dual_edge_aldff(base_name,
@@ -1567,11 +1665,13 @@ public:
 
 						for (auto driven_chunk2 : dffe_q.chunks())
 						for (auto [named_chunk, name] : generate_subfield_names(driven_chunk2, type)) {
-							std::string base_name = Yosys::stringf("$driver$%s%s",
-								RTLIL::unescape_id(netlist.id(*named_chunk.variable.get_symbol())).c_str(), name.c_str());
+							auto *named_symbol = named_chunk.variable.get_symbol();
+							log_assert(named_symbol != nullptr);
+							std::string base_name = ff_naming_base_name_from_options(settings, netlist, block_symbol,
+									disambiguate_block_name, *named_symbol, name);
 
 							netlist.add_dffe(base_name,
-											 timing.triggers[0].signal,
+										 timing.triggers[0].signal,
 											 aloads[0].trigger,
 											 assigned.extract((int)(named_chunk.base - driven_chunk.base), (int)named_chunk.bitwidth()),
 											 netlist.convert_static(named_chunk),
@@ -2943,6 +3043,12 @@ void fixup_options(SynthesisSettings &settings, slang::driver::Driver &driver)
 
 	if (!settings.no_synthesis_define.value_or(false)) {
 		driver.options.defines.push_back("SYNTHESIS=1");
+	}
+
+	if (settings.ff_naming.has_value()) {
+		auto &mode = settings.ff_naming.value();
+		if (mode != "legacy" && mode != "signal" && mode != "auto")
+			log_cmd_error("Unknown --ff-naming mode '%s'\n", mode.c_str());
 	}
 
 	if (!settings.no_default_translate_off.value_or(false)) {

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -81,12 +81,9 @@ void SynthesisSettings::addOptions(slang::CommandLine &cmdLine) {
 			" When set to 'error', an error is emitted if a UDP is encountered. By default, the frontend emits an error.");
 	cmdLine.add("--ff-naming", ff_naming,
 				"Set the naming scheme used for flip-flops inferred from always_ff blocks."
-				" Valid values: legacy, signal, auto."
-				" Note: 'auto' names are unstable and may change across versions.", "<mode>");
-	cmdLine.add("--ff-prefix", ff_prefix,
-				"Set the prefix prepended to inferred flip-flop names.", "<prefix>");
-	cmdLine.add("--ff-suffix", ff_suffix,
-				"Set the suffix appended to inferred flip-flop names.", "<suffix>");
+				" Valid values: signal, auto, or a template using {sep=<separator>}, {scope}, {proc},"
+				" {signal}, and {proc_auto}. For example: '{sep=_}{scope}{proc_auto}_reg'."
+				" Example name: 'gen_gpios_0_capture_reg'.", "<scheme>");
 
 	// Deprecated section
 	cmdLine.add("--compat-mode", compat_mode,
@@ -199,59 +196,152 @@ static const ast::StatementBlockSymbol *ff_naming_auto_block(const ast::Statemen
 	return nullptr;
 }
 
+static std::string ff_naming_template_from_scheme(std::string_view scheme)
+{
+	if (scheme == "legacy")
+		return "legacy";
+	if (scheme == "signal")
+		return "{sep=_}{scope}{signal}_reg";
+	if (scheme == "auto")
+		return "{sep=_}{scope}{proc_auto}_reg";
+	return std::string(scheme);
+}
+
+static std::optional<std::string> ff_naming_template_error(std::string_view scheme)
+{
+	if (scheme == "legacy")
+		return std::nullopt;
+
+	bool saw_placeholder = false;
+	std::string tmpl = ff_naming_template_from_scheme(scheme);
+
+	for (size_t i = 0; i < tmpl.size(); i++) {
+		if (tmpl[i] != '{' && tmpl[i] != '}')
+			continue;
+
+		size_t close = tmpl.find('}', i);
+		if (tmpl[i] != '{' || close == std::string::npos)
+			return Yosys::stringf("Invalid --ff-naming template '%s'\n", std::string(scheme).c_str());
+
+		std::string_view placeholder(tmpl.data() + i + 1, close - i - 1);
+		if (placeholder != "scope" && placeholder != "proc" && placeholder != "signal" &&
+				placeholder != "proc_auto" && placeholder.compare(0, 4, "sep=") != 0)
+			return Yosys::stringf("Unknown --ff-naming placeholder '{%s}'\n", std::string(placeholder).c_str());
+
+		saw_placeholder = true;
+		i = close;
+	}
+
+	if (!saw_placeholder)
+		return Yosys::stringf("Unknown --ff-naming scheme '%s'\n", std::string(scheme).c_str());
+
+	return std::nullopt;
+}
+
 // Build the final inferred flip-flop base name from the active ff naming options
 static std::string ff_naming_base_name_from_options(SynthesisSettings &settings, NetlistContext &netlist,
 		const ast::StatementBlockSymbol *block_symbol, bool disambiguate_block_name,
 		const ast::ValueSymbol &symbol, std::string_view subfield_suffix)
 {
-	auto mode = settings.ff_naming_mode();
-	std::string prefix = settings.ff_naming_prefix();
-	std::string suffix = settings.ff_naming_suffix();
+	std::string tmpl = ff_naming_template_from_scheme(settings.ff_naming_mode());
+	if (tmpl == "legacy")
+		return std::string("\\$driver$") + ff_naming_legacy_signal_name(netlist, symbol, subfield_suffix);
 
+	std::string sep = "_";
+	std::optional<std::string> scope_name;
+	std::optional<std::string> proc_name;
+	std::optional<std::string> signal_name;
+	std::optional<std::string> proc_auto_name;
 
-	// Avoid duplicating the configured suffix when the base name already ends in it
-	auto maybe_append_suffix = [&](std::string name) {
-		if (!suffix.empty() && name.size() >= suffix.size() &&
-				name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0)
-				return name;
-		return name + suffix;
+	auto *symbol_scope = symbol.getParentScope();
+	ast_invariant(symbol, symbol_scope != nullptr);
+
+	auto get_scope_name = [&]() {
+		if (!scope_name)
+			scope_name = format_scope_name_fragment(&netlist.realm, symbol_scope, sep);
+		return scope_name.value();
 	};
 
-	auto make_public = [](std::string name) {
-		return std::string("\\") + name;
-	};
-
-	// Avoid duplicating the configured prefix when the base name already starts with it
-	auto with_prefix = [&](std::string name) {
-		if (!prefix.empty() && name.size() >= prefix.size() &&
-				name.compare(0, prefix.size(), prefix) == 0)
-			return make_public(name);
-		return make_public(prefix + name);
-	};
-
-	if (mode == "legacy") {
-		std::string base_name = ff_naming_legacy_signal_name(netlist, symbol, subfield_suffix);
-		base_name = maybe_append_suffix(base_name);
-		return with_prefix(base_name);
-	}
-
-	std::string signal_name = format_signal_name_fragment(&netlist.realm, symbol, subfield_suffix);
-
-	if (mode == "signal")
-		return with_prefix(maybe_append_suffix(signal_name));
-	if (mode == "auto") {
-		if (block_symbol) {
-			auto *symbol_scope = symbol.getParentScope();
-			ast_invariant(symbol, symbol_scope != nullptr);
-			std::string local_signal_name = format_signal_name_fragment(symbol_scope, symbol, subfield_suffix);
-			std::string block_name = format_scope_name_fragment(&netlist.realm, block_symbol);
-			if (disambiguate_block_name)
-				return with_prefix(maybe_append_suffix(block_name + "_" + local_signal_name));
-			return with_prefix(maybe_append_suffix(block_name));
+	auto get_proc_name = [&]() {
+		if (!proc_name) {
+			if (block_symbol)
+				proc_name = format_scope_name_fragment(symbol_scope, block_symbol, sep);
+			else
+				proc_name = "";
 		}
-		return with_prefix(maybe_append_suffix(signal_name));
+		return proc_name.value();
+	};
+
+	auto get_signal_name = [&]() {
+		if (!signal_name)
+			signal_name = format_signal_name_fragment(symbol_scope, symbol, subfield_suffix, sep);
+		return signal_name.value();
+	};
+
+	auto get_proc_auto_name = [&]() {
+		if (proc_auto_name)
+			return proc_auto_name.value();
+
+		std::string block_name = get_proc_name();
+		if (!block_name.empty()) {
+			if (disambiguate_block_name)
+				proc_auto_name = block_name + sep + get_signal_name();
+			else
+				proc_auto_name = block_name;
+		} else {
+			proc_auto_name = get_signal_name();
+		}
+		return proc_auto_name.value();
+	};
+
+	auto reset_parts = [&]() {
+		scope_name.reset();
+		proc_name.reset();
+		signal_name.reset();
+		proc_auto_name.reset();
+	};
+
+	bool last_token_was_part = false;
+	auto append_part = [&](std::string_view part, std::string &ret) {
+		if (part.empty())
+			return;
+
+		if (last_token_was_part && !sep.empty())
+			ret += sep;
+		ret += part;
+		last_token_was_part = true;
+	};
+
+	std::string ret;
+	for (size_t i = 0; i < tmpl.size(); i++) {
+		if (tmpl[i] != '{') {
+			ret.push_back(tmpl[i]);
+			last_token_was_part = false;
+			continue;
+		}
+
+		size_t close = tmpl.find('}', i);
+		log_assert(close != std::string::npos);
+		std::string_view placeholder(tmpl.data() + i + 1, close - i - 1);
+
+		if (placeholder.compare(0, 4, "sep=") == 0) {
+			sep = std::string(placeholder.substr(4));
+			reset_parts();
+		} else if (placeholder == "scope")
+			append_part(get_scope_name(), ret);
+		else if (placeholder == "proc")
+			append_part(get_proc_name(), ret);
+		else if (placeholder == "signal")
+			append_part(get_signal_name(), ret);
+		else if (placeholder == "proc_auto")
+			append_part(get_proc_auto_name(), ret);
+		else
+			log_abort();
+
+		i = close;
 	}
-	log_abort();
+
+	return std::string("\\") + ret;
 }
 
 static const RTLIL::Const convert_svint(const slang::SVInt &svint)
@@ -1577,11 +1667,38 @@ public:
 			// FIXME: ignores variables not driven from the sync procedure
 			VariableBits driven = sync_procedure.all_driven();
 			const ast::StatementBlockSymbol *block_symbol = ff_naming_auto_block(prologue_block, sync_body);
-			int emitted_ff_names = 0;
-			for (VariableChunk driven_chunk : driven.chunks()) {
-				const ast::Type *type = &driven_chunk.variable.get_symbol()->getType();
-				emitted_ff_names += generate_subfield_names(driven_chunk, type).size();
-			}
+			auto count_emitted_ff_names = [&]() {
+				int emitted_ff_names = 0;
+				auto add_chunk_names = [&](VariableChunk chunk) {
+					const ast::Type *type = &chunk.variable.get_symbol()->getType();
+					emitted_ff_names += generate_subfield_names(chunk, type).size();
+				};
+
+				if (aloads.empty()) {
+					for (VariableChunk driven_chunk : driven.chunks())
+						add_chunk_names(driven_chunk);
+				} else {
+					for (VariableChunk driven_chunk : driven.chunks()) {
+						VariableBits aldff_q;
+						VariableBits dffe_q;
+
+						for (uint64_t i = 0; i < driven_chunk.bitwidth(); i++) {
+							if (aloads[0].values.visible_assignments.count(driven_chunk[i]))
+								aldff_q.append(driven_chunk[i]);
+							else
+								dffe_q.append(driven_chunk[i]);
+						}
+
+						for (auto chunk : aldff_q.chunks())
+							add_chunk_names(chunk);
+						for (auto chunk : dffe_q.chunks())
+							add_chunk_names(chunk);
+					}
+				}
+
+				return emitted_ff_names;
+			};
+			int emitted_ff_names = count_emitted_ff_names();
 			bool disambiguate_block_name = emitted_ff_names > 1;
 
 			for (VariableChunk driven_chunk : driven.chunks()) {
@@ -3047,9 +3164,8 @@ void fixup_options(SynthesisSettings &settings, slang::driver::Driver &driver)
 	}
 
 	if (settings.ff_naming.has_value()) {
-		auto &mode = settings.ff_naming.value();
-		if (mode != "legacy" && mode != "signal" && mode != "auto")
-			log_cmd_error("Unknown --ff-naming mode '%s'\n", mode.c_str());
+		if (auto error = ff_naming_template_error(settings.ff_naming_mode()))
+			log_cmd_error("%s", error->c_str());
 	}
 
 	if (!settings.no_default_translate_off.value_or(false)) {

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -453,6 +453,9 @@ struct SynthesisSettings {
 	std::optional<bool> allow_dual_edge_ff;
 	std::optional<bool> no_synthesis_define;
 	std::optional<UdpHandleMode> udp_handling;
+	std::optional<std::string> ff_naming;
+	std::optional<std::string> ff_prefix;
+	std::optional<std::string> ff_suffix;
 	// pass std::less<> to enable transparent lookup
 	std::set<std::string, std::less<>> blackboxed_modules;
 	bool disable_instance_caching = false;
@@ -474,6 +477,26 @@ struct SynthesisSettings {
 
 	int unroll_limit() {
 		return unroll_limit_.value_or(4000);
+	}
+
+	std::string ff_naming_mode() {
+		return ff_naming.value_or("legacy");
+	}
+
+	std::string ff_naming_prefix() {
+		if (ff_prefix.has_value())
+			return ff_prefix.value();
+		if (ff_naming_mode() == "legacy")
+			return "$driver$";
+		return "";
+	}
+
+	std::string ff_naming_suffix() {
+		if (ff_suffix.has_value())
+			return ff_suffix.value();
+		if (ff_naming_mode() == "legacy")
+			return "";
+		return "_reg";
 	}
 
 	void addOptions(slang::CommandLine &cmdLine);
@@ -597,6 +620,9 @@ extern void export_blackbox_to_rtlil(NetlistContext &netlist, const ast::Instanc
 // naming.cc
 typedef std::pair<VariableChunk, std::string> NamedChunk;
 std::vector<NamedChunk> generate_subfield_names(VariableChunk chunk, const ast::Type *type);
+std::string format_scope_name_fragment(const ast::Scope *relative_to, const ast::Scope *scope);
+std::string format_signal_name_fragment(const ast::Scope *relative_to, const ast::ValueSymbol &symbol,
+		std::string_view suffix);
 
 // initialization.cc
 void evaluate_decl_initializers(NetlistContext &netlist);

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -454,8 +454,6 @@ struct SynthesisSettings {
 	std::optional<bool> no_synthesis_define;
 	std::optional<UdpHandleMode> udp_handling;
 	std::optional<std::string> ff_naming;
-	std::optional<std::string> ff_prefix;
-	std::optional<std::string> ff_suffix;
 	// pass std::less<> to enable transparent lookup
 	std::set<std::string, std::less<>> blackboxed_modules;
 	bool disable_instance_caching = false;
@@ -481,22 +479,6 @@ struct SynthesisSettings {
 
 	std::string ff_naming_mode() {
 		return ff_naming.value_or("legacy");
-	}
-
-	std::string ff_naming_prefix() {
-		if (ff_prefix.has_value())
-			return ff_prefix.value();
-		if (ff_naming_mode() == "legacy")
-			return "$driver$";
-		return "";
-	}
-
-	std::string ff_naming_suffix() {
-		if (ff_suffix.has_value())
-			return ff_suffix.value();
-		if (ff_naming_mode() == "legacy")
-			return "";
-		return "_reg";
 	}
 
 	void addOptions(slang::CommandLine &cmdLine);
@@ -620,9 +602,10 @@ extern void export_blackbox_to_rtlil(NetlistContext &netlist, const ast::Instanc
 // naming.cc
 typedef std::pair<VariableChunk, std::string> NamedChunk;
 std::vector<NamedChunk> generate_subfield_names(VariableChunk chunk, const ast::Type *type);
-std::string format_scope_name_fragment(const ast::Scope *relative_to, const ast::Scope *scope);
+std::string format_scope_name_fragment(const ast::Scope *relative_to, const ast::Scope *scope,
+		std::string_view sep="_"sv);
 std::string format_signal_name_fragment(const ast::Scope *relative_to, const ast::ValueSymbol &symbol,
-		std::string_view suffix);
+		std::string_view suffix, std::string_view sep="_"sv);
 
 // initialization.cc
 void evaluate_decl_initializers(NetlistContext &netlist);

--- a/tests/various/flop_naming.ys
+++ b/tests/various/flop_naming.ys
@@ -55,3 +55,178 @@ select -assert-any t:$*ff* c:$driver$a[1].field1 %i
 select -assert-any t:$*ff* c:$driver$a[1].field0 %i
 select -assert-any t:$*ff* c:$driver$a[0].field1 %i
 select -assert-any t:$*ff* c:$driver$a[0].field0 %i
+
+design -reset
+read_slang --ff-naming signal <<EOF
+module top(input logic clk);
+	typedef struct packed {
+		logic valid;
+		struct packed {
+			logic [1:0] opcode;
+		} header;
+	} packet_t;
+
+	packet_t state_q, state_d;
+
+	always_ff @(posedge clk)
+		state_q <= state_d;
+endmodule
+EOF
+select -assert-count 2 t:$*ff*
+select -assert-any t:$*ff* c:state_q_valid_reg %i
+select -assert-any t:$*ff* c:state_q_header_opcode_reg %i
+
+design -reset
+read_slang --ff-naming signal <<EOF
+module top(input logic clk);
+	logic [3:0] state_q, state_d;
+
+	always_ff @(posedge clk)
+		state_q[2] <= state_d[2];
+endmodule
+EOF
+select -assert-count 1 t:$*ff*
+select -assert-any t:$*ff* n:*state_q_2_reg %i
+
+design -reset
+read_slang --ff-naming signal <<EOF
+module top(input logic clk);
+	logic [7:0] state_q, state_d;
+
+	always_ff @(posedge clk)
+		state_q[5:2] <= state_d[5:2];
+endmodule
+EOF
+select -assert-count 1 t:$*ff*
+select -assert-any t:$*ff* c:state_q_5downto2_reg %i
+
+design -reset
+read_slang --ff-naming auto <<EOF
+module top(input logic clk);
+	logic state_q, state_d;
+
+	always_ff @(posedge clk) begin : state_update
+		state_q <= state_d;
+	end
+endmodule
+EOF
+select -assert-count 1 t:$*ff*
+select -assert-any t:$*ff* c:state_update_reg %i
+
+design -reset
+read_slang --ff-naming auto <<EOF
+module top(input logic clk);
+	logic a_q, a_d, b_q, b_d;
+
+	always_ff @(posedge clk) begin : regs
+		a_q <= a_d;
+		b_q <= b_d;
+	end
+endmodule
+EOF
+select -assert-count 2 t:$*ff*
+select -assert-any t:$*ff* c:regs_a_q_reg %i
+select -assert-any t:$*ff* c:regs_b_q_reg %i
+
+design -reset
+read_slang --ff-naming auto <<EOF
+module top(input logic clk);
+	genvar i;
+	for (i = 0; i < 2; i++) begin : gen_gpios
+		logic serial_q, serial_d;
+		always_ff @(posedge clk) begin : capture
+			serial_q <= serial_d;
+		end
+	end
+endmodule
+EOF
+select -assert-count 2 t:$*ff*
+select -assert-any t:$*ff* c:gen_gpios_0_capture_reg %i
+select -assert-any t:$*ff* c:gen_gpios_1_capture_reg %i
+
+design -reset
+read_slang --ff-naming signal <<EOF
+module top(input logic clk);
+	genvar i;
+	for (i = 0; i < 2; i++) begin : gen_gpios
+		logic serial_q, serial_d;
+		always_ff @(posedge clk)
+			serial_q <= serial_d;
+	end
+endmodule
+EOF
+select -assert-count 2 t:$*ff*
+select -assert-any t:$*ff* c:gen_gpios_0_serial_q_reg %i
+select -assert-any t:$*ff* c:gen_gpios_1_serial_q_reg %i
+
+design -reset
+read_slang --ff-naming signal <<EOF
+module top(input logic clk, input logic d);
+	always_ff @(posedge clk) begin
+		static logic local_q;
+		local_q <= d;
+	end
+endmodule
+EOF
+select -assert-count 1 t:$*ff*
+select -assert-any t:$*ff* n:*__*_local_q_reg %i
+
+design -reset
+read_slang --ff-naming auto <<EOF
+module top(input logic clk);
+	logic state_reg, state_d;
+
+	always_ff @(posedge clk)
+		state_reg <= state_d;
+endmodule
+EOF
+select -assert-count 1 t:$*ff*
+select -assert-any t:$*ff* n:state_reg* %i
+
+design -reset
+read_slang --ff-naming signal --ff-suffix _ff <<EOF
+module top(input logic clk);
+	logic state_q, state_d;
+
+	always_ff @(posedge clk)
+		state_q <= state_d;
+endmodule
+EOF
+select -assert-count 1 t:$*ff*
+select -assert-any t:$*ff* c:state_q_ff %i
+
+design -reset
+read_slang --ff-naming signal --ff-prefix dbg_ <<EOF
+module top(input logic clk);
+	logic dbg_state_q, state_d;
+
+	always_ff @(posedge clk)
+		dbg_state_q <= state_d;
+endmodule
+EOF
+select -assert-count 1 t:$*ff*
+select -assert-any t:$*ff* n:*dbg_state_q_reg %i
+
+design -reset
+read_slang --ff-naming legacy --ff-prefix dbg_ <<EOF
+module top(input logic clk);
+	logic state_q, state_d;
+
+	always_ff @(posedge clk)
+		state_q <= state_d;
+endmodule
+EOF
+select -assert-count 1 t:$*ff*
+select -assert-any t:$*ff* c:dbg_state_q %i
+
+design -reset
+read_slang --ff-naming legacy --ff-suffix _ff <<EOF
+module top(input logic clk);
+	logic state_q, state_d;
+
+	always_ff @(posedge clk)
+		state_q <= state_d;
+endmodule
+EOF
+select -assert-count 1 t:$*ff*
+select -assert-any t:$*ff* n:*\$driver$state_q_ff %i

--- a/tests/various/flop_naming.ys
+++ b/tests/various/flop_naming.ys
@@ -145,6 +145,56 @@ select -assert-any t:$*ff* c:gen_gpios_0_capture_reg %i
 select -assert-any t:$*ff* c:gen_gpios_1_capture_reg %i
 
 design -reset
+read_slang --ff-naming {sep=-}{scope}{proc_auto}-ff <<EOF
+module top(input logic clk);
+	genvar i;
+	for (i = 0; i < 2; i++) begin : gen_gpios
+		logic serial_q, serial_d;
+		always_ff @(posedge clk) begin : capture
+			serial_q <= serial_d;
+		end
+	end
+endmodule
+EOF
+select -assert-count 2 t:$*ff*
+select -assert-any t:$*ff* c:gen_gpios-0-capture-ff %i
+select -assert-any t:$*ff* c:gen_gpios-1-capture-ff %i
+
+design -reset
+read_slang --ff-naming {sep=_}{scope}{proc_auto}_reg <<EOF
+module top(input logic clk);
+	genvar i;
+	for (i = 0; i < 2; i++) begin : gen_gpios
+		logic serial_q, serial_d;
+		always_ff @(posedge clk)
+			serial_q <= serial_d;
+	end
+endmodule
+EOF
+select -assert-count 2 t:$*ff*
+select -assert-any t:$*ff* c:gen_gpios_0_serial_q_reg %i
+select -assert-any t:$*ff* c:gen_gpios_1_serial_q_reg %i
+
+design -reset
+read_slang --ff-naming {sep=_}{scope}{proc_auto}_reg <<EOF
+module top(input logic clk);
+	genvar i;
+	for (i = 0; i < 2; i++) begin : gen_gpios
+		logic a_q, a_d, b_q, b_d;
+		always_ff @(posedge clk) begin : capture
+			a_q <= a_d;
+			b_q <= b_d;
+		end
+	end
+endmodule
+EOF
+select -assert-count 4 t:$*ff*
+select -assert-any t:$*ff* c:gen_gpios_0_capture_a_q_reg %i
+select -assert-any t:$*ff* c:gen_gpios_0_capture_b_q_reg %i
+select -assert-any t:$*ff* c:gen_gpios_1_capture_a_q_reg %i
+select -assert-any t:$*ff* c:gen_gpios_1_capture_b_q_reg %i
+
+design -reset
 read_slang --ff-naming signal <<EOF
 module top(input logic clk);
 	genvar i;
@@ -169,7 +219,7 @@ module top(input logic clk, input logic d);
 endmodule
 EOF
 select -assert-count 1 t:$*ff*
-select -assert-any t:$*ff* n:*__*_local_q_reg %i
+select -assert-any t:$*ff* n:*_local_q_reg %i
 
 design -reset
 read_slang --ff-naming auto <<EOF
@@ -181,10 +231,10 @@ module top(input logic clk);
 endmodule
 EOF
 select -assert-count 1 t:$*ff*
-select -assert-any t:$*ff* n:state_reg* %i
+select -assert-any t:$*ff* n:state_reg_reg* %i
 
 design -reset
-read_slang --ff-naming signal --ff-suffix _ff <<EOF
+read_slang --ff-naming {sep=_}{signal}_ff <<EOF
 module top(input logic clk);
 	logic state_q, state_d;
 
@@ -196,19 +246,19 @@ select -assert-count 1 t:$*ff*
 select -assert-any t:$*ff* c:state_q_ff %i
 
 design -reset
-read_slang --ff-naming signal --ff-prefix dbg_ <<EOF
+read_slang --ff-naming {sep=-}{scope}{signal}-ff <<EOF
 module top(input logic clk);
-	logic dbg_state_q, state_d;
+	logic [7:0] state_q, state_d;
 
 	always_ff @(posedge clk)
-		dbg_state_q <= state_d;
+		state_q[5:2] <= state_d[5:2];
 endmodule
 EOF
 select -assert-count 1 t:$*ff*
-select -assert-any t:$*ff* n:*dbg_state_q_reg %i
+select -assert-any t:$*ff* c:state_q-5downto2-ff %i
 
 design -reset
-read_slang --ff-naming legacy --ff-prefix dbg_ <<EOF
+read_slang --ff-naming dbg_{sep=_}{signal}_reg <<EOF
 module top(input logic clk);
 	logic state_q, state_d;
 
@@ -217,16 +267,65 @@ module top(input logic clk);
 endmodule
 EOF
 select -assert-count 1 t:$*ff*
-select -assert-any t:$*ff* c:dbg_state_q %i
+select -assert-any t:$*ff* c:dbg_state_q_reg %i
 
 design -reset
-read_slang --ff-naming legacy --ff-suffix _ff <<EOF
+read_slang --ff-naming {sep=_}{scope}{proc}{signal}_reg <<EOF
 module top(input logic clk);
 	logic state_q, state_d;
 
-	always_ff @(posedge clk)
+	always_ff @(posedge clk) begin : regs
 		state_q <= state_d;
+	end
 endmodule
 EOF
 select -assert-count 1 t:$*ff*
-select -assert-any t:$*ff* n:*\$driver$state_q_ff %i
+select -assert-any t:$*ff* c:regs_state_q_reg %i
+
+design -reset
+read_slang --ff-naming {sep=_}{scope}{proc}{signal}_reg <<EOF
+module top(input logic clk);
+	genvar i;
+	for (i = 0; i < 2; i++) begin : gen_gpios
+		logic serial_q, serial_d;
+		always_ff @(posedge clk)
+			serial_q <= serial_d;
+	end
+endmodule
+EOF
+select -assert-count 2 t:$*ff*
+select -assert-any t:$*ff* c:gen_gpios_0_serial_q_reg %i
+select -assert-any t:$*ff* c:gen_gpios_1_serial_q_reg %i
+
+design -reset
+read_slang --ff-naming {sep=_}{scope}{proc}{signal}_reg <<EOF
+module top(input logic clk);
+	genvar i;
+	for (i = 0; i < 2; i++) begin : gen_gpios
+		logic serial_q, serial_d;
+		always_ff @(posedge clk) begin : capture
+			serial_q <= serial_d;
+		end
+	end
+endmodule
+EOF
+select -assert-count 2 t:$*ff*
+select -assert-any t:$*ff* c:gen_gpios_0_capture_serial_q_reg %i
+select -assert-any t:$*ff* c:gen_gpios_1_capture_serial_q_reg %i
+
+design -reset
+read_slang --ff-naming auto <<EOF
+module top(input logic clk, input logic rst_n, input logic [7:0] d);
+	logic [7:0] q;
+
+	always_ff @(posedge clk or negedge rst_n) begin : regs
+		if (!rst_n)
+			q[0] <= 1'b0;
+		else
+			q <= d;
+	end
+endmodule
+EOF
+select -assert-count 2 t:$*ff*
+select -assert-any t:$*ff* c:regs_q_0_reg %i
+select -assert-any t:$*ff* c:regs_q_7downto1_reg %i


### PR DESCRIPTION
The legacy scheme remains the default and keeps the existing `$driver$<signal><subfield>` naming.

Added options:
- `--ff-naming=legacy|signal|auto` Selects the naming scheme for inferred flip-flops. `signal` derives names only from the driven signal and subfields, while `auto` uses named always_ff blocks and after that the signal-based scheme.
- `--ff-prefix=<prefix>` Prepends a custom prefix to inferred flip-flop names. By default this is empty for the new schemes and `$driver$` for `legacy`.
- `--ff-suffix=<suffix>` Appends a custom suffix to non-legacy flip-flop names. The default is `_reg`, the suffix is not duplicated if the base name already ends in it.

It also flattens struct and generate-block hierarchy into the name, distinguishes scope numbers from array indices and shows packed slices.


Some example names it generates:
```
gpio$croc_chip.i_croc_soc.i_croc.i_gpio/gen_gpios_1_serial_q_reg
gpio$croc_chip.i_croc_soc.i_croc.i_gpio/gen_gpios_0_serial_q_reg
soc_ctrl_regs$croc_chip.i_croc_soc.i_croc.i_soc_ctrl/core_status_q_reg
cve2_if_stage$croc_chip.i_croc_soc.i_croc.i_core_wrap.i_core.if_stage_i/instr_fetch_err_o_reg
cve2_if_stage$croc_chip.i_croc_soc.i_croc.i_core_wrap.i_core.if_stage_i/instr_is_compressed_id_o_reg
cve2_if_stage$croc_chip.i_croc_soc.i_croc.i_core_wrap.i_core.if_stage_i/instr_rdata_c_id_o_reg
cve2_if_stage$croc_chip.i_croc_soc.i_croc.i_core_wrap.i_core.if_stage_i/instr_rdata_alu_id_o_reg
fifo_v3$croc_chip.i_croc_soc.i_croc.i_uart.i_uart_rx.i_fifo_v3/mem_q_2_reg
fifo_v3$croc_chip.i_croc_soc.i_croc.i_uart.i_uart_rx.i_fifo_v3/mem_q_1_reg
fifo_v3$croc_chip.i_croc_soc.i_croc.i_uart.i_uart_rx.i_fifo_v3/mem_q_0_reg
```