### PR TITLE
Add parameter-based module uniquification

### DIFF
--- a/src/builder.cc
+++ b/src/builder.cc
@@ -24,7 +24,9 @@ static IdString id(std::string_view sv)
 #else
 static IdString id(std::string_view sv)
 {
-	return sv;
+	if (sv.empty() || sv[0] == '$' || sv[0] == '\\')
+		return sv;
+	return RTLIL::escape_id(std::string(sv));
 }
 #endif
 

--- a/src/initialization.cc
+++ b/src/initialization.cc
@@ -24,7 +24,7 @@ template <typename Func> void visit_netlist_variables(NetlistContext &netlist, F
 				}
 			},
 			[&](auto &visitor, const ast::InstanceSymbol &symbol) {
-				if (netlist.should_dissolve(symbol))
+				if (netlist.settings.should_dissolve(symbol))
 					visitor.visitDefault(symbol);
 			},
 			[&](auto &, const ast::ProceduralBlockSymbol &) {

--- a/src/naming.cc
+++ b/src/naming.cc
@@ -81,7 +81,8 @@ std::vector<NamedChunk> generate_subfield_names(VariableChunk chunk, const ast::
 	return ret;
 }
 
-// Format one raw hierarchy or signal name into a friendly identifier
+// Format one raw hierarchy or signal name into an alphanumeric+underscore identifier fragment
+// Makes it easy to use and compose in Tcl-style contexts without escaping characters
 static std::string format_name_fragment(std::string_view raw)
 {
 	std::string ret;

--- a/src/naming.cc
+++ b/src/naming.cc
@@ -4,6 +4,8 @@
 // Copyright Martin Povišer <povik@cutebit.org>
 // Distributed under the terms of the ISC license, see LICENSE
 //
+#include <cctype>
+
 #include "slang/ast/symbols/VariableSymbols.h"
 #include "slang/ast/types/Type.h"
 
@@ -77,6 +79,110 @@ std::vector<NamedChunk> generate_subfield_names(VariableChunk chunk, const ast::
 	log_assert(sum == chunk.bitwidth());
 
 	return ret;
+}
+
+// Format one raw hierarchy or signal name into a friendly identifier
+static std::string format_name_fragment(std::string_view raw)
+{
+	std::string ret;
+	ret.reserve(raw.size() + 8);
+
+	auto push_sep = [&]() {
+		if (!ret.empty() && ret.back() != '_')
+			ret.push_back('_');
+	};
+
+	for (size_t i = 0; i < raw.size(); i++) {
+		unsigned char ch = raw[i];
+
+		// Alphanumeric and underscore characters are kept as-is
+		if (std::isalnum(ch) || ch == '_') {
+			ret.push_back(ch);
+			continue;
+		}
+
+		// Flatten dotted hierarchy and subfields into underscores
+		if (ch == '.') {
+			push_sep();
+			continue;
+		}
+
+		// `$<n>` comes from unnamed scopes; keep it distinct from `[n]`, which is an array index.
+		if (ch == '$' && i + 1 < raw.size() && std::isdigit((unsigned char)raw[i + 1])) {
+			if (ret.empty() || ret.back() != '_')
+				ret.push_back('_');
+			ret.push_back('_');
+			i++;
+			while (i < raw.size() && std::isdigit((unsigned char)raw[i])) {
+				ret.push_back(raw[i]);
+				i++;
+			}
+			i--;
+			continue;
+		}
+
+		// Add packed and unpacked indices as explicit suffixes
+		if (ch == '[') {
+			push_sep();
+
+			std::string lhs_index;
+			size_t j = i + 1;
+			while (j < raw.size() && raw[j] != ']' && raw[j] != ':') {
+				lhs_index.push_back(raw[j]);
+				j++;
+			}
+			ret.append(lhs_index);
+
+			if (j < raw.size() && raw[j] == ':') {
+				// Keep multi-bit slices explicit so ranges remain readable
+				j++;
+				std::string rhs;
+				while (j < raw.size() && raw[j] != ']') {
+					rhs.push_back(raw[j]);
+					j++;
+				}
+
+				if (lhs_index != rhs) {
+					ret.append("downto");
+					ret.append(rhs);
+				}
+			}
+
+			while (j < raw.size() && raw[j] != ']')
+				j++;
+			i = j;
+			continue;
+		}
+
+		// Collapse any remaining symbols into a separator
+		push_sep();
+	}
+
+	while (!ret.empty() && ret.back() == '_')
+		ret.pop_back();
+
+	return ret;
+}
+
+// Format a scope path relative to another scope using the naming fragment rules above.
+std::string format_scope_name_fragment(const ast::Scope *relative_to, const ast::Scope *scope)
+{
+	return format_name_fragment(hierpath_relative_to(relative_to, scope));
+}
+
+// Format a signal path plus optional subfield or slice suffix into one name fragment.
+std::string format_signal_name_fragment(const ast::Scope *relative_to, const ast::ValueSymbol &symbol,
+		std::string_view suffix)
+{
+	auto *scope = symbol.getParentScope();
+	ast_invariant(symbol, scope != nullptr);
+
+	std::string raw = hierpath_relative_to(relative_to, scope);
+	if (!raw.empty())
+		raw.push_back('.');
+	raw.append(symbol.name);
+	raw.append(suffix);
+	return format_name_fragment(raw);
 }
 
 }; // namespace slang_frontend

--- a/src/naming.cc
+++ b/src/naming.cc
@@ -81,16 +81,21 @@ std::vector<NamedChunk> generate_subfield_names(VariableChunk chunk, const ast::
 	return ret;
 }
 
-// Format one raw hierarchy or signal name into an alphanumeric+underscore identifier fragment
-// Makes it easy to use and compose in Tcl-style contexts without escaping characters
-static std::string format_name_fragment(std::string_view raw)
+// Format one raw hierarchy or signal name into an alphanumeric / separator identifier fragment.
+// Makes it easy to use and compose in Tcl-style contexts without escaping characters.
+static std::string format_name_fragment(std::string_view raw, std::string_view sep)
 {
 	std::string ret;
 	ret.reserve(raw.size() + 8);
 
+	auto ends_with_sep = [&]() {
+		return !sep.empty() && ret.size() >= sep.size() &&
+			ret.compare(ret.size() - sep.size(), sep.size(), sep) == 0;
+	};
+
 	auto push_sep = [&]() {
-		if (!ret.empty() && ret.back() != '_')
-			ret.push_back('_');
+		if (!ret.empty() && !ends_with_sep())
+			ret.append(sep);
 	};
 
 	for (size_t i = 0; i < raw.size(); i++) {
@@ -110,9 +115,8 @@ static std::string format_name_fragment(std::string_view raw)
 
 		// `$<n>` comes from unnamed scopes; keep it distinct from `[n]`, which is an array index.
 		if (ch == '$' && i + 1 < raw.size() && std::isdigit((unsigned char)raw[i + 1])) {
-			if (ret.empty() || ret.back() != '_')
-				ret.push_back('_');
-			ret.push_back('_');
+			push_sep();
+			ret.append(sep);
 			i++;
 			while (i < raw.size() && std::isdigit((unsigned char)raw[i])) {
 				ret.push_back(raw[i]);
@@ -159,21 +163,22 @@ static std::string format_name_fragment(std::string_view raw)
 		push_sep();
 	}
 
-	while (!ret.empty() && ret.back() == '_')
-		ret.pop_back();
+	while (ends_with_sep())
+		ret.resize(ret.size() - sep.size());
 
 	return ret;
 }
 
 // Format a scope path relative to another scope using the naming fragment rules above.
-std::string format_scope_name_fragment(const ast::Scope *relative_to, const ast::Scope *scope)
+std::string format_scope_name_fragment(const ast::Scope *relative_to, const ast::Scope *scope,
+		std::string_view sep)
 {
-	return format_name_fragment(hierpath_relative_to(relative_to, scope));
+	return format_name_fragment(hierpath_relative_to(relative_to, scope), sep);
 }
 
 // Format a signal path plus optional subfield or slice suffix into one name fragment.
 std::string format_signal_name_fragment(const ast::Scope *relative_to, const ast::ValueSymbol &symbol,
-		std::string_view suffix)
+		std::string_view suffix, std::string_view sep)
 {
 	auto *scope = symbol.getParentScope();
 	ast_invariant(symbol, scope != nullptr);
@@ -183,7 +188,7 @@ std::string format_signal_name_fragment(const ast::Scope *relative_to, const ast
 		raw.push_back('.');
 	raw.append(symbol.name);
 	raw.append(suffix);
-	return format_name_fragment(raw);
+	return format_name_fragment(raw, sep);
 }
 
 }; // namespace slang_frontend

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -208,10 +208,6 @@ static std::string ff_naming_base_name_from_options(SynthesisSettings &settings,
 	std::string prefix = settings.ff_naming_prefix();
 	std::string suffix = settings.ff_naming_suffix();
 
-	std::string signal_name = format_signal_name_fragment(&netlist.realm, symbol, subfield_suffix);
-	auto *symbol_scope = symbol.getParentScope();
-	ast_invariant(symbol, symbol_scope != nullptr);
-	std::string local_signal_name = format_signal_name_fragment(symbol_scope, symbol, subfield_suffix);
 
 	// Avoid duplicating the configured suffix when the base name already ends in it
 	auto maybe_append_suffix = [&](std::string name) {
@@ -239,10 +235,15 @@ static std::string ff_naming_base_name_from_options(SynthesisSettings &settings,
 		return with_prefix(base_name);
 	}
 
+	std::string signal_name = format_signal_name_fragment(&netlist.realm, symbol, subfield_suffix);
+
 	if (mode == "signal")
 		return with_prefix(maybe_append_suffix(signal_name));
 	if (mode == "auto") {
 		if (block_symbol) {
+			auto *symbol_scope = symbol.getParentScope();
+			ast_invariant(symbol, symbol_scope != nullptr);
+			std::string local_signal_name = format_signal_name_fragment(symbol_scope, symbol, subfield_suffix);
 			std::string block_name = format_scope_name_fragment(&netlist.realm, block_symbol);
 			if (disambiguate_block_name)
 				return with_prefix(maybe_append_suffix(block_name + "_" + local_signal_name));

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -79,6 +79,14 @@ void SynthesisSettings::addOptions(slang::CommandLine &cmdLine) {
 			"--udp-handling", udp_handling, "Set the processing mode for user defined primitives."
 			" When set to 'blackboxes' the UDP is treated as a blackboxed instance."
 			" When set to 'error', an error is emitted if a UDP is encountered. By default, the frontend emits an error.");
+	cmdLine.add("--ff-naming", ff_naming,
+				"Set the naming scheme used for flip-flops inferred from always_ff blocks."
+				" Valid values: legacy, signal, auto."
+				" Note: 'auto' names are unstable and may change across versions.", "<mode>");
+	cmdLine.add("--ff-prefix", ff_prefix,
+				"Set the prefix prepended to inferred flip-flop names.", "<prefix>");
+	cmdLine.add("--ff-suffix", ff_suffix,
+				"Set the suffix appended to inferred flip-flop names.", "<suffix>");
 
 	// Deprecated section
 	cmdLine.add("--compat-mode", compat_mode,
@@ -163,6 +171,86 @@ static const RTLIL::IdString module_type_id(const ast::InstanceBodySymbol &sym)
 		return RTLIL::escape_id(std::string(sym.name));
 	else
 		return RTLIL::escape_id(std::string(sym.name) + "$" + instance);
+}
+
+// Return the pre-prefix flip-flop base name used by the legacy scheme
+static std::string ff_naming_legacy_signal_name(NetlistContext &netlist, const ast::ValueSymbol &symbol,
+		std::string_view suffix)
+{
+	return Yosys::stringf("%s%s",
+			RTLIL::unescape_id(netlist.id(symbol)).c_str(), std::string(suffix).c_str());
+}
+
+// Find the named block that `--ff-naming auto` should prefer, if there is one
+static const ast::StatementBlockSymbol *ff_naming_auto_block(const ast::StatementBlockSymbol *prologue_block,
+		const ast::Statement &sync_body)
+{
+	if (prologue_block && !prologue_block->name.empty())
+		return prologue_block;
+
+	if (sync_body.kind != ast::StatementKind::Block)
+		return nullptr;
+
+	auto &block = sync_body.as<ast::BlockStatement>();
+	ast_invariant(sync_body, block.blockKind == ast::StatementBlockKind::Sequential);
+	if (block.blockSymbol && !block.blockSymbol->name.empty())
+		return block.blockSymbol;
+
+	return nullptr;
+}
+
+// Build the final inferred flip-flop base name from the active ff naming options
+static std::string ff_naming_base_name_from_options(SynthesisSettings &settings, NetlistContext &netlist,
+		const ast::StatementBlockSymbol *block_symbol, bool disambiguate_block_name,
+		const ast::ValueSymbol &symbol, std::string_view subfield_suffix)
+{
+	auto mode = settings.ff_naming_mode();
+	std::string prefix = settings.ff_naming_prefix();
+	std::string suffix = settings.ff_naming_suffix();
+
+	std::string signal_name = format_signal_name_fragment(&netlist.realm, symbol, subfield_suffix);
+	auto *symbol_scope = symbol.getParentScope();
+	ast_invariant(symbol, symbol_scope != nullptr);
+	std::string local_signal_name = format_signal_name_fragment(symbol_scope, symbol, subfield_suffix);
+
+	// Avoid duplicating the configured suffix when the base name already ends in it
+	auto maybe_append_suffix = [&](std::string name) {
+		if (!suffix.empty() && name.size() >= suffix.size() &&
+				name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0)
+				return name;
+		return name + suffix;
+	};
+
+	auto make_public = [](std::string name) {
+		return std::string("\\") + name;
+	};
+
+	// Avoid duplicating the configured prefix when the base name already starts with it
+	auto with_prefix = [&](std::string name) {
+		if (!prefix.empty() && name.size() >= prefix.size() &&
+				name.compare(0, prefix.size(), prefix) == 0)
+			return make_public(name);
+		return make_public(prefix + name);
+	};
+
+	if (mode == "legacy") {
+		std::string base_name = ff_naming_legacy_signal_name(netlist, symbol, subfield_suffix);
+		base_name = maybe_append_suffix(base_name);
+		return with_prefix(base_name);
+	}
+
+	if (mode == "signal")
+		return with_prefix(maybe_append_suffix(signal_name));
+	if (mode == "auto") {
+		if (block_symbol) {
+			std::string block_name = format_scope_name_fragment(&netlist.realm, block_symbol);
+			if (disambiguate_block_name)
+				return with_prefix(maybe_append_suffix(block_name + "_" + local_signal_name));
+			return with_prefix(maybe_append_suffix(block_name));
+		}
+		return with_prefix(maybe_append_suffix(signal_name));
+	}
+	log_abort();
 }
 
 static const RTLIL::Const convert_svint(const slang::SVInt &svint)
@@ -1487,6 +1575,14 @@ public:
 
 			// FIXME: ignores variables not driven from the sync procedure
 			VariableBits driven = sync_procedure.all_driven();
+			const ast::StatementBlockSymbol *block_symbol = ff_naming_auto_block(prologue_block, sync_body);
+			int emitted_ff_names = 0;
+			for (VariableChunk driven_chunk : driven.chunks()) {
+				const ast::Type *type = &driven_chunk.variable.get_symbol()->getType();
+				emitted_ff_names += generate_subfield_names(driven_chunk, type).size();
+			}
+			bool disambiguate_block_name = emitted_ff_names > 1;
+
 			for (VariableChunk driven_chunk : driven.chunks()) {
 				const ast::Type *type = &driven_chunk.variable.get_symbol()->getType();
 				RTLIL::SigSpec assigned = sync_procedure.vstate.evaluate(netlist, driven_chunk);
@@ -1497,9 +1593,10 @@ public:
 				if (aloads.empty()) {
 
 					for (auto [named_chunk, name] : generate_subfield_names(driven_chunk, type)) {
-						log_assert(named_chunk.variable.get_symbol() != nullptr);
-						std::string base_name = Yosys::stringf("$driver$%s%s",
-							RTLIL::unescape_id(netlist.id(*named_chunk.variable.get_symbol())).c_str(), name.c_str());
+						auto *named_symbol = named_chunk.variable.get_symbol();
+						log_assert(named_symbol != nullptr);
+						std::string base_name = ff_naming_base_name_from_options(settings, netlist, block_symbol,
+								disambiguate_block_name, *named_symbol, name);
 
 						if (clock.edge == ast::EdgeKind::BothEdges) {
 							netlist.add_dual_edge_aldff(base_name,
@@ -1533,9 +1630,10 @@ public:
 					if (!aldff_q.empty()) {
 						for (auto driven_chunk2 : aldff_q.chunks())
 						for (auto [named_chunk, name] : generate_subfield_names(driven_chunk2, type)) {
-							log_assert(named_chunk.variable.get_symbol() != nullptr);
-							std::string base_name = Yosys::stringf("$driver$%s%s",
-								RTLIL::unescape_id(netlist.id(*named_chunk.variable.get_symbol())).c_str(), name.c_str());
+							auto *named_symbol = named_chunk.variable.get_symbol();
+							log_assert(named_symbol != nullptr);
+							std::string base_name = ff_naming_base_name_from_options(settings, netlist, block_symbol,
+									disambiguate_block_name, *named_symbol, name);
 
 							if (clock.edge == ast::EdgeKind::BothEdges) {
 								netlist.add_dual_edge_aldff(base_name,
@@ -1567,11 +1665,13 @@ public:
 
 						for (auto driven_chunk2 : dffe_q.chunks())
 						for (auto [named_chunk, name] : generate_subfield_names(driven_chunk2, type)) {
-							std::string base_name = Yosys::stringf("$driver$%s%s",
-								RTLIL::unescape_id(netlist.id(*named_chunk.variable.get_symbol())).c_str(), name.c_str());
+							auto *named_symbol = named_chunk.variable.get_symbol();
+							log_assert(named_symbol != nullptr);
+							std::string base_name = ff_naming_base_name_from_options(settings, netlist, block_symbol,
+									disambiguate_block_name, *named_symbol, name);
 
 							netlist.add_dffe(base_name,
-											 timing.triggers[0].signal,
+										 timing.triggers[0].signal,
 											 aloads[0].trigger,
 											 assigned.extract((int)(named_chunk.base - driven_chunk.base), (int)named_chunk.bitwidth()),
 											 netlist.convert_static(named_chunk),
@@ -2943,6 +3043,12 @@ void fixup_options(SynthesisSettings &settings, slang::driver::Driver &driver)
 
 	if (!settings.no_synthesis_define.value_or(false)) {
 		driver.options.defines.push_back("SYNTHESIS=1");
+	}
+
+	if (settings.ff_naming.has_value()) {
+		auto &mode = settings.ff_naming.value();
+		if (mode != "legacy" && mode != "signal" && mode != "auto")
+			log_cmd_error("Unknown --ff-naming mode '%s'\n", mode.c_str());
 	}
 
 	if (!settings.no_default_translate_off.value_or(false)) {

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -81,12 +81,9 @@ void SynthesisSettings::addOptions(slang::CommandLine &cmdLine) {
 			" When set to 'error', an error is emitted if a UDP is encountered. By default, the frontend emits an error.");
 	cmdLine.add("--ff-naming", ff_naming,
 				"Set the naming scheme used for flip-flops inferred from always_ff blocks."
-				" Valid values: legacy, signal, auto."
-				" Note: 'auto' names are unstable and may change across versions.", "<mode>");
-	cmdLine.add("--ff-prefix", ff_prefix,
-				"Set the prefix prepended to inferred flip-flop names.", "<prefix>");
-	cmdLine.add("--ff-suffix", ff_suffix,
-				"Set the suffix appended to inferred flip-flop names.", "<suffix>");
+				" Valid values: signal, auto, or a template using {sep=<separator>}, {scope}, {proc},"
+				" {signal}, and {proc_auto}. For example: '{sep=_}{scope}{proc_auto}_reg'."
+				" Example name: 'gen_gpios_0_capture_reg'.", "<scheme>");
 
 	// Deprecated section
 	cmdLine.add("--compat-mode", compat_mode,
@@ -199,59 +196,152 @@ static const ast::StatementBlockSymbol *ff_naming_auto_block(const ast::Statemen
 	return nullptr;
 }
 
+static std::string ff_naming_template_from_scheme(std::string_view scheme)
+{
+	if (scheme == "legacy")
+		return "legacy";
+	if (scheme == "signal")
+		return "{sep=_}{scope}{signal}_reg";
+	if (scheme == "auto")
+		return "{sep=_}{scope}{proc_auto}_reg";
+	return std::string(scheme);
+}
+
+static std::optional<std::string> ff_naming_template_error(std::string_view scheme)
+{
+	if (scheme == "legacy")
+		return std::nullopt;
+
+	bool saw_placeholder = false;
+	std::string tmpl = ff_naming_template_from_scheme(scheme);
+
+	for (size_t i = 0; i < tmpl.size(); i++) {
+		if (tmpl[i] != '{' && tmpl[i] != '}')
+			continue;
+
+		size_t close = tmpl.find('}', i);
+		if (tmpl[i] != '{' || close == std::string::npos)
+			return Yosys::stringf("Invalid --ff-naming template '%s'\n", std::string(scheme).c_str());
+
+		std::string_view placeholder(tmpl.data() + i + 1, close - i - 1);
+		if (placeholder != "scope" && placeholder != "proc" && placeholder != "signal" &&
+				placeholder != "proc_auto" && placeholder.compare(0, 4, "sep=") != 0)
+			return Yosys::stringf("Unknown --ff-naming placeholder '{%s}'\n", std::string(placeholder).c_str());
+
+		saw_placeholder = true;
+		i = close;
+	}
+
+	if (!saw_placeholder)
+		return Yosys::stringf("Unknown --ff-naming scheme '%s'\n", std::string(scheme).c_str());
+
+	return std::nullopt;
+}
+
 // Build the final inferred flip-flop base name from the active ff naming options
 static std::string ff_naming_base_name_from_options(SynthesisSettings &settings, NetlistContext &netlist,
 		const ast::StatementBlockSymbol *block_symbol, bool disambiguate_block_name,
 		const ast::ValueSymbol &symbol, std::string_view subfield_suffix)
 {
-	auto mode = settings.ff_naming_mode();
-	std::string prefix = settings.ff_naming_prefix();
-	std::string suffix = settings.ff_naming_suffix();
+	std::string tmpl = ff_naming_template_from_scheme(settings.ff_naming_mode());
+	if (tmpl == "legacy")
+		return std::string("\\$driver$") + ff_naming_legacy_signal_name(netlist, symbol, subfield_suffix);
 
+	std::string sep = "_";
+	std::optional<std::string> scope_name;
+	std::optional<std::string> proc_name;
+	std::optional<std::string> signal_name;
+	std::optional<std::string> proc_auto_name;
 
-	// Avoid duplicating the configured suffix when the base name already ends in it
-	auto maybe_append_suffix = [&](std::string name) {
-		if (!suffix.empty() && name.size() >= suffix.size() &&
-				name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0)
-				return name;
-		return name + suffix;
+	auto *symbol_scope = symbol.getParentScope();
+	ast_invariant(symbol, symbol_scope != nullptr);
+
+	auto get_scope_name = [&]() {
+		if (!scope_name)
+			scope_name = format_scope_name_fragment(&netlist.realm, symbol_scope, sep);
+		return scope_name.value();
 	};
 
-	auto make_public = [](std::string name) {
-		return std::string("\\") + name;
-	};
-
-	// Avoid duplicating the configured prefix when the base name already starts with it
-	auto with_prefix = [&](std::string name) {
-		if (!prefix.empty() && name.size() >= prefix.size() &&
-				name.compare(0, prefix.size(), prefix) == 0)
-			return make_public(name);
-		return make_public(prefix + name);
-	};
-
-	if (mode == "legacy") {
-		std::string base_name = ff_naming_legacy_signal_name(netlist, symbol, subfield_suffix);
-		base_name = maybe_append_suffix(base_name);
-		return with_prefix(base_name);
-	}
-
-	std::string signal_name = format_signal_name_fragment(&netlist.realm, symbol, subfield_suffix);
-
-	if (mode == "signal")
-		return with_prefix(maybe_append_suffix(signal_name));
-	if (mode == "auto") {
-		if (block_symbol) {
-			auto *symbol_scope = symbol.getParentScope();
-			ast_invariant(symbol, symbol_scope != nullptr);
-			std::string local_signal_name = format_signal_name_fragment(symbol_scope, symbol, subfield_suffix);
-			std::string block_name = format_scope_name_fragment(&netlist.realm, block_symbol);
-			if (disambiguate_block_name)
-				return with_prefix(maybe_append_suffix(block_name + "_" + local_signal_name));
-			return with_prefix(maybe_append_suffix(block_name));
+	auto get_proc_name = [&]() {
+		if (!proc_name) {
+			if (block_symbol)
+				proc_name = format_scope_name_fragment(symbol_scope, block_symbol, sep);
+			else
+				proc_name = "";
 		}
-		return with_prefix(maybe_append_suffix(signal_name));
+		return proc_name.value();
+	};
+
+	auto get_signal_name = [&]() {
+		if (!signal_name)
+			signal_name = format_signal_name_fragment(symbol_scope, symbol, subfield_suffix, sep);
+		return signal_name.value();
+	};
+
+	auto get_proc_auto_name = [&]() {
+		if (proc_auto_name)
+			return proc_auto_name.value();
+
+		std::string block_name = get_proc_name();
+		if (!block_name.empty()) {
+			if (disambiguate_block_name)
+				proc_auto_name = block_name + sep + get_signal_name();
+			else
+				proc_auto_name = block_name;
+		} else {
+			proc_auto_name = get_signal_name();
+		}
+		return proc_auto_name.value();
+	};
+
+	auto reset_parts = [&]() {
+		scope_name.reset();
+		proc_name.reset();
+		signal_name.reset();
+		proc_auto_name.reset();
+	};
+
+	bool last_token_was_part = false;
+	auto append_part = [&](std::string_view part, std::string &ret) {
+		if (part.empty())
+			return;
+
+		if (last_token_was_part && !sep.empty())
+			ret += sep;
+		ret += part;
+		last_token_was_part = true;
+	};
+
+	std::string ret;
+	for (size_t i = 0; i < tmpl.size(); i++) {
+		if (tmpl[i] != '{') {
+			ret.push_back(tmpl[i]);
+			last_token_was_part = false;
+			continue;
+		}
+
+		size_t close = tmpl.find('}', i);
+		log_assert(close != std::string::npos);
+		std::string_view placeholder(tmpl.data() + i + 1, close - i - 1);
+
+		if (placeholder.compare(0, 4, "sep=") == 0) {
+			sep = std::string(placeholder.substr(4));
+			reset_parts();
+		} else if (placeholder == "scope")
+			append_part(get_scope_name(), ret);
+		else if (placeholder == "proc")
+			append_part(get_proc_name(), ret);
+		else if (placeholder == "signal")
+			append_part(get_signal_name(), ret);
+		else if (placeholder == "proc_auto")
+			append_part(get_proc_auto_name(), ret);
+		else
+			log_abort();
+
+		i = close;
 	}
-	log_abort();
+
+	return std::string("\\") + ret;
 }
 
 static const RTLIL::Const convert_svint(const slang::SVInt &svint)
@@ -1577,11 +1667,38 @@ public:
 			// FIXME: ignores variables not driven from the sync procedure
 			VariableBits driven = sync_procedure.all_driven();
 			const ast::StatementBlockSymbol *block_symbol = ff_naming_auto_block(prologue_block, sync_body);
-			int emitted_ff_names = 0;
-			for (VariableChunk driven_chunk : driven.chunks()) {
-				const ast::Type *type = &driven_chunk.variable.get_symbol()->getType();
-				emitted_ff_names += generate_subfield_names(driven_chunk, type).size();
-			}
+			auto count_emitted_ff_names = [&]() {
+				int emitted_ff_names = 0;
+				auto add_chunk_names = [&](VariableChunk chunk) {
+					const ast::Type *type = &chunk.variable.get_symbol()->getType();
+					emitted_ff_names += generate_subfield_names(chunk, type).size();
+				};
+
+				if (aloads.empty()) {
+					for (VariableChunk driven_chunk : driven.chunks())
+						add_chunk_names(driven_chunk);
+				} else {
+					for (VariableChunk driven_chunk : driven.chunks()) {
+						VariableBits aldff_q;
+						VariableBits dffe_q;
+
+						for (uint64_t i = 0; i < driven_chunk.bitwidth(); i++) {
+							if (aloads[0].values.visible_assignments.count(driven_chunk[i]))
+								aldff_q.append(driven_chunk[i]);
+							else
+								dffe_q.append(driven_chunk[i]);
+						}
+
+						for (auto chunk : aldff_q.chunks())
+							add_chunk_names(chunk);
+						for (auto chunk : dffe_q.chunks())
+							add_chunk_names(chunk);
+					}
+				}
+
+				return emitted_ff_names;
+			};
+			int emitted_ff_names = count_emitted_ff_names();
 			bool disambiguate_block_name = emitted_ff_names > 1;
 
 			for (VariableChunk driven_chunk : driven.chunks()) {
@@ -3047,9 +3164,8 @@ void fixup_options(SynthesisSettings &settings, slang::driver::Driver &driver)
 	}
 
 	if (settings.ff_naming.has_value()) {
-		auto &mode = settings.ff_naming.value();
-		if (mode != "legacy" && mode != "signal" && mode != "auto")
-			log_cmd_error("Unknown --ff-naming mode '%s'\n", mode.c_str());
+		if (auto error = ff_naming_template_error(settings.ff_naming_mode()))
+			log_cmd_error("%s", error->c_str());
 	}
 
 	if (!settings.no_default_translate_off.value_or(false)) {

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -8,9 +8,12 @@
 #include "slang/ast/ASTVisitor.h"
 #include "slang/ast/Compilation.h"
 #include "slang/ast/EvalContext.h"
+#include "slang/ast/InstanceCacheKey.h"
 #include "slang/ast/SemanticFacts.h"
 #include "slang/ast/SystemSubroutine.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
+#include "slang/ast/symbols/ParameterSymbols.h"
+#include "slang/ast/types/TypePrinter.h"
 #include "slang/diagnostics/CompilationDiags.h"
 #include "slang/diagnostics/DiagnosticEngine.h"
 #include "slang/diagnostics/LookupDiags.h"
@@ -35,6 +38,9 @@
 #include "diag.h"
 #include "async_pattern.h"
 #include "variables.h"
+
+#include <cctype>
+#include <optional>
 
 namespace slang_frontend {
 
@@ -84,6 +90,10 @@ void SynthesisSettings::addOptions(slang::CommandLine &cmdLine) {
 				" Valid values: signal, auto, or a template using {sep=<separator>}, {scope}, {proc},"
 				" {signal}, and {proc_auto}. For example: '{sep=_}{scope}{proc_auto}_reg'."
 				" Example name: 'gen_gpios_0_capture_reg'.", "<scheme>");
+	cmdLine.addEnum<ModuleUniquifyMode, ModuleUniquifyMode_traits>(
+			"--module-uniquify", module_uniquify,
+			"Set how preserved modules are uniquified. 'instance' keeps the current instance-path based names."
+			" 'param' emits one module per unique parameterization and adds a parameter suffix only when needed.");
 
 	// Deprecated section
 	cmdLine.add("--compat-mode", compat_mode,
@@ -160,14 +170,19 @@ uint64_t bitstream_member_offset(const ast::FieldSymbol &member)
 	return bit_offset;
 }
 
-static const RTLIL::IdString module_type_id(const ast::InstanceBodySymbol &sym)
+static std::string module_type_name(const ast::InstanceBodySymbol &sym)
 {
 	ast_invariant(sym, sym.parentInstance && sym.parentInstance->isModule());
 	std::string instance = sym.getHierarchicalPath();
 	if (instance == sym.name)
-		return RTLIL::escape_id(std::string(sym.name));
+		return std::string(sym.name);
 	else
-		return RTLIL::escape_id(std::string(sym.name) + "$" + instance);
+		return std::string(sym.name) + "$" + instance;
+}
+
+static const RTLIL::IdString module_type_id(const ast::InstanceBodySymbol &sym)
+{
+	return RTLIL::escape_id(module_type_name(sym));
 }
 
 // Return the pre-prefix flip-flop base name used by the legacy scheme
@@ -1479,15 +1494,383 @@ EvalContext::EvalContext(NetlistContext &netlist, ProceduralContext &procedural)
 {
 }
 
+bool SynthesisSettings::is_blackbox(const ast::DefinitionSymbol &sym, slang::Diagnostic *why_blackbox)
+{
+	if (sym.cellDefine)
+		return true;
+
+	if (blackboxed_modules.contains(sym.name))
+		return true;
+
+	for (auto attr : sym.getParentScope()->getCompilation().getAttributes(sym)) {
+		if (attr->name == "blackbox"sv && !attr->getValue().isFalse()) {
+			if (why_blackbox) {
+				auto &note = why_blackbox->addNote(diag::NoteModuleBlackboxBecauseAttribute,
+													attr->location);
+				note << sym.name;
+			}
+			return true;
+		}
+	}
+
+	if (empty_blackboxes.value_or(false)) {
+		if (why_blackbox) {
+			auto &note = why_blackbox->addNote(diag::NoteModuleBlackboxBecauseEmpty, sym.location);
+			note << sym.name;
+		}
+		return is_decl_empty_module(*sym.getSyntax());
+	}
+
+	return false;
+}
+
+bool SynthesisSettings::should_dissolve(const ast::InstanceSymbol &sym, slang::Diagnostic *why_not_dissolved)
+{
+	if (sym.isModule() && is_blackbox(sym.body.getDefinition())) {
+		if (why_not_dissolved) {
+			auto &note = why_not_dissolved->addNote(diag::NoteModuleNotDissolvedBecauseBlackbox, sym.location);
+			note << sym.body.name;
+			is_blackbox(sym.body.getDefinition(), why_not_dissolved);
+		}
+		return false;
+	}
+
+	if (sym.isInterface())
+		return true;
+
+	switch (hierarchy_mode()) {
+	case SynthesisSettings::NONE:
+		return true;
+	case SynthesisSettings::BEST_EFFORT: {
+		for (auto *conn : sym.getPortConnections()) {
+			switch (conn->port.kind) {
+			case ast::SymbolKind::Port:
+			case ast::SymbolKind::MultiPort:
+				break;
+			case ast::SymbolKind::InterfacePort:
+				if (!conn->getIfaceConn().second)
+					return true;
+				break;
+			default:
+				return true;
+			}
+		}
+
+		if (!sym.isModule())
+			return true;
+
+		return false;
+	}
+	case SynthesisSettings::ALL:
+		if (why_not_dissolved) {
+			auto &note = why_not_dissolved->addNote(diag::NoteModuleNotDissolvedBecauseKeepHierarchy, sym.location);
+			note << sym.body.name;
+		}
+	default:
+		return false;
+	}
+}
+
+static std::string module_name_fragment(std::string_view raw)
+{
+	std::string ret;
+	bool last_sep = false;
+
+	for (size_t i = 0; i < raw.size(); i++) {
+		unsigned char ch = raw[i];
+		if (std::isalnum(ch) || ch == '_') {
+			ret.push_back(ch);
+			last_sep = false;
+		} else if (ch == ':' && i > 0 && i + 1 < raw.size() &&
+				std::isdigit((unsigned char)raw[i - 1]) && std::isdigit((unsigned char)raw[i + 1])) {
+			size_t lhs = i - 1;
+			while (lhs > 0 && std::isdigit((unsigned char)raw[lhs - 1]))
+				lhs--;
+			size_t rhs = i + 1;
+			while (rhs + 1 < raw.size() && std::isdigit((unsigned char)raw[rhs + 1]))
+				rhs++;
+
+			std::string_view left = raw.substr(lhs, i - lhs);
+			std::string_view right = raw.substr(i + 1, rhs - i);
+			while (left.size() > 1 && left.front() == '0')
+				left.remove_prefix(1);
+			while (right.size() > 1 && right.front() == '0')
+				right.remove_prefix(1);
+
+			bool descending = left.size() != right.size() ? left.size() > right.size() : left >= right;
+			ret += descending ? "downto" : "upto";
+			last_sep = false;
+		} else if (!ret.empty() && !last_sep) {
+			ret.push_back('_');
+			last_sep = true;
+		}
+	}
+
+	while (!ret.empty() && ret.back() == '_')
+		ret.pop_back();
+
+	return ret;
+}
+
+struct ModuleParamText {
+	std::string signature;
+	std::string suffix;
+};
+
+static std::string module_param_value_suffix(const slang::ConstantValue &value)
+{
+	if (value.isInteger()) {
+		auto &integer = value.integer();
+		std::string ret;
+		if (integer.hasUnknown()) {
+			ret = "b";
+			ret += integer.toString(slang::LiteralBase::Binary, false, slang::SVInt::MAX_BITS);
+		} else {
+			ret = integer.toString(slang::LiteralBase::Decimal, false, slang::SVInt::MAX_BITS);
+			if (!ret.empty() && ret.front() == '-')
+				ret.replace(0, 1, "m");
+		}
+		return ret;
+	}
+
+	return value.toString(slang::SVInt::MAX_BITS, true);
+}
+
+static ModuleParamText module_param_text(const ast::InstanceSymbol &instance)
+{
+	ModuleParamText ret;
+	ast::TypePrinter type_printer;
+	type_printer.options.skipScopedTypeNames = true;
+	type_printer.options.fullEnumType = true;
+
+	auto append_suffix_part = [&](std::string_view name, std::string_view value) {
+		std::string name_fragment = module_name_fragment(name);
+		std::string value_fragment = module_name_fragment(value);
+		if (name_fragment.empty() || value_fragment.empty())
+			return;
+
+		if (!ret.suffix.empty())
+			ret.suffix += "__";
+		ret.suffix += name_fragment;
+		ret.suffix += "_";
+		ret.suffix += value_fragment;
+	};
+
+	for (auto *param : instance.body.getParameters()) {
+		if (param->isLocalParam())
+			continue;
+
+		if (param->symbol.kind == ast::SymbolKind::Parameter) {
+			auto &symbol = param->symbol.as<ast::ParameterSymbol>();
+			auto &const_value = symbol.getValue();
+			std::string value = const_value.toString(slang::SVInt::MAX_BITS, true);
+			ret.signature += "param ";
+			ret.signature += symbol.name;
+			ret.signature += "=";
+			ret.signature += value;
+			ret.signature += "\n";
+			append_suffix_part(symbol.name, module_param_value_suffix(const_value));
+		} else {
+			auto &symbol = param->symbol.as<ast::TypeParameterSymbol>();
+			type_printer.append(symbol.targetType.getType().getCanonicalType());
+			std::string value = type_printer.toString();
+			ret.signature += "type ";
+			ret.signature += symbol.name;
+			ret.signature += "=";
+			ret.signature += value;
+			ret.signature += "\n";
+			append_suffix_part(symbol.name, value);
+			type_printer.clear();
+		}
+	}
+
+	return ret;
+}
+
+static std::string module_hash_fragment(std::string_view raw)
+{
+	uint32_t hash = 2166136261u;
+	for (unsigned char ch : raw) {
+		hash ^= ch;
+		hash *= 16777619u;
+	}
+	return Yosys::stringf("p%08x", hash);
+}
+
+struct ModuleNameResolver {
+	struct Variant {
+		const ast::InstanceBodySymbol *body;
+		std::string signature;
+		std::optional<ast::InstanceCacheKey> cache_key;
+		bool top = false;
+		RTLIL::IdString module_name;
+	};
+
+	SynthesisSettings &settings;
+	std::vector<Variant> variants;
+	std::map<const ast::InstanceBodySymbol *, size_t> variant_by_body;
+	std::map<std::string, int> param_variant_counts;
+
+	ModuleNameResolver(SynthesisSettings &settings) : settings(settings) {}
+
+	bool parameter_mode() const
+	{
+		return settings.module_uniquify_mode() != ModuleUniquifyMode::instance;
+	}
+
+	size_t add_variant(const ast::InstanceSymbol &instance, bool top)
+	{
+		const ast::InstanceBodySymbol *body = &get_instance_body(settings, instance);
+
+		if (!parameter_mode()) {
+			size_t index = variants.size();
+			variants.push_back(Variant{body, "", std::nullopt, top, module_type_id(*body)});
+			variant_by_body[body] = index;
+			return index;
+		}
+
+		if (top) {
+			if (variant_by_body.count(body))
+				return variant_by_body.at(body);
+
+			size_t index = variants.size();
+			variants.push_back(Variant{body, "", std::nullopt, true,
+					RTLIL::escape_id(std::string(body->name))});
+			variant_by_body[body] = index;
+			return index;
+		}
+
+		if (variant_by_body.count(body) && variants[variant_by_body.at(body)].top)
+			return variant_by_body.at(body);
+
+		bool valid = ast::InstanceCacheKey::isEligibleForCaching(instance);
+		slang::SmallSet<const ast::InstanceSymbol *, 2> visited;
+		std::optional<ast::InstanceCacheKey> cache_key;
+		if (valid)
+			cache_key.emplace(instance, valid, visited);
+
+		for (size_t index = 0; index < variants.size(); index++) {
+			auto &variant = variants[index];
+			if (variant.body->name != body->name)
+				continue;
+			if (variant.top || !variant.cache_key)
+				continue;
+			if (valid && variant.cache_key && *variant.cache_key == *cache_key) {
+				variant_by_body[body] = index;
+				return index;
+			}
+		}
+
+		size_t index = variants.size();
+		if (valid) {
+			auto text = module_param_text(instance);
+			variants.push_back(Variant{body, std::move(text.signature), std::move(cache_key), false, {}});
+		} else {
+			variants.push_back(Variant{body, "", std::nullopt, false, {}});
+		}
+		variant_by_body[body] = index;
+		if (valid)
+			param_variant_counts[std::string(body->name)]++;
+		return index;
+	}
+
+	void scan_instance(const ast::InstanceSymbol &instance, bool top=false)
+	{
+		if (instance.getDefinition().definitionKind == ast::DefinitionKind::Program)
+			return;
+
+		if (instance.isModule() && settings.is_blackbox(instance.body.getDefinition()))
+			return;
+
+		bool preserved = top || (instance.isModule() && !settings.should_dissolve(instance));
+		const ast::InstanceBodySymbol *body = &get_instance_body(settings, instance);
+		if (preserved)
+			add_variant(instance, top);
+
+		body->visit(ast::makeVisitor([&](auto&, const ast::InstanceSymbol &child) {
+			scan_instance(child);
+		}));
+	}
+
+	void finalize()
+	{
+		std::set<std::string> used_names;
+		for (auto &variant : variants) {
+			if (variant.top) {
+				used_names.insert(std::string(variant.module_name.str()));
+				continue;
+			}
+			if (!parameter_mode())
+				used_names.insert(std::string(variant.module_name.str()));
+		}
+
+		for (auto &variant : variants) {
+			if (variant.top || !parameter_mode())
+				continue;
+
+			if (!variant.cache_key) {
+				// If slang cannot form an InstanceCacheKey, keep the old instance-path uniquification.
+				std::string name = module_type_name(*variant.body);
+				variant.module_name = RTLIL::escape_id(name);
+				used_names.insert(std::string(variant.module_name.str()));
+				continue;
+			}
+
+			std::string name = std::string(variant.body->name);
+			// In param mode, plain names are used unless they would be ambiguous.
+			bool needs_suffix = param_variant_counts[name] > 1 || used_names.count(RTLIL::escape_id(name));
+
+			if (needs_suffix) {
+				std::string suffix = module_param_text(*variant.body->parentInstance).suffix;
+				if (suffix.empty() || suffix.size() > 80)
+					suffix = module_hash_fragment(variant.signature);
+				name += "__" + suffix;
+			}
+
+			RTLIL::IdString id = RTLIL::escape_id(name);
+			if (used_names.count(id.str())) {
+				// Parameter text is not the whole InstanceCacheKey; interface-keyed variants can still collide.
+				name += "__" + module_hash_fragment(module_type_name(*variant.body));
+				id = RTLIL::escape_id(name);
+			}
+
+			variant.module_name = id;
+			used_names.insert(id.str());
+		}
+	}
+
+	RTLIL::IdString module_name(const ast::InstanceBodySymbol &body) const
+	{
+		auto it = variant_by_body.find(&body);
+		ast_invariant(body, it != variant_by_body.end());
+		return variants.at(it->second).module_name;
+	}
+
+	std::string parameter_signature(const ast::InstanceBodySymbol &body) const
+	{
+		auto it = variant_by_body.find(&body);
+		ast_invariant(body, it != variant_by_body.end());
+		return variants.at(it->second).signature;
+	}
+};
+
 struct HierarchyQueue {
+	ModuleNameResolver &module_names;
+
+	HierarchyQueue(ModuleNameResolver &module_names) : module_names(module_names) {}
+
 	template<class... Args>
 	std::pair<NetlistContext&, bool> get_or_emplace(const ast::InstanceBodySymbol *symbol, Args&&... args)
 	{
-		if (netlists.count(symbol)) {
-			return {*netlists.at(symbol), false};
+		RTLIL::IdString name = module_names.module_name(*symbol);
+		if (netlists.count(name)) {
+			return {*netlists.at(name), false};
 		} else {
-			NetlistContext *ref = new NetlistContext(args...);
-			netlists[symbol] = ref;
+			NetlistContext *ref = new NetlistContext(args..., name);
+			std::string signature = module_names.parameter_signature(*symbol);
+			if (!signature.empty())
+				ref->canvas->set_string_attribute(RTLIL::escape_id("slang_parameterization"), signature);
+			netlists[name] = ref;
 			queue.push_back(ref);
 			return {*ref, true};
 		}
@@ -1499,7 +1882,7 @@ struct HierarchyQueue {
 			delete netlist;
 	}
 
-	std::map<const ast::InstanceBodySymbol *, NetlistContext *> netlists;
+	std::map<RTLIL::IdString, NetlistContext *> netlists;
 	std::vector<NetlistContext *> queue;
 };
 
@@ -1514,7 +1897,9 @@ public:
 	PopulateNetlist(HierarchyQueue &queue, NetlistContext &netlist)
 		: TimingPatternInterpretor(netlist.settings, (DiagnosticIssuer&) netlist, netlist.eval),
 		  queue(queue), netlist(netlist), settings(netlist.settings),
-		  mem_detect(settings, std::bind(&NetlistContext::should_dissolve, &netlist, std::placeholders::_1, nullptr), netlist.eval) {}
+		  mem_detect(settings, [&](const ast::InstanceSymbol &sym) {
+			  return settings.should_dissolve(sym);
+		  }, netlist.eval) {}
 
 	void handle_comb_like_process(const ast::ProceduralBlockSymbol &symbol, const ast::Statement &body)
 	{
@@ -1949,7 +2334,7 @@ public:
 		}
 
 		// blackboxes get special handling no matter the hierarchy mode
-		if (sym.isModule() && netlist.is_blackbox(sym.body.getDefinition())) {
+		if (sym.isModule() && settings.is_blackbox(sym.body.getDefinition())) {
 			RTLIL::Cell *cell = netlist.canvas->addCell(netlist.id(sym), RTLIL::escape_id(std::string(sym.body.name)));
 			cell->set_string_attribute(ID::hdlname, netlist.hdlname(sym));
 
@@ -2015,7 +2400,7 @@ public:
 			return;
 		}
 
-		if (netlist.should_dissolve(sym)) {
+		if (settings.should_dissolve(sym)) {
 			sym.body.visit(*this);
 
 			for (auto *conn : sym.getPortConnections()) {
@@ -2117,7 +2502,7 @@ public:
 			ast_invariant(sym, ref_body->parentInstance != nullptr);
 			auto [submodule, inserted] = queue.get_or_emplace(ref_body, netlist, *ref_body->parentInstance);
 
-			RTLIL::Cell *cell = netlist.canvas->addCell(netlist.id(sym), module_type_id(*ref_body));
+			RTLIL::Cell *cell = netlist.canvas->addCell(netlist.id(sym), queue.module_names.module_name(*ref_body));
 			cell->set_string_attribute(ID::hdlname, netlist.hdlname(sym));
 			for (auto *conn : sym.getPortConnections()) {
 				slang::SourceLocation loc;
@@ -2361,7 +2746,7 @@ public:
 				netlist.add_wire(sym);
 			}
 		}, [&](auto& visitor, const ast::InstanceSymbol& sym) {
-			if (netlist.should_dissolve(sym))
+			if (netlist.settings.should_dissolve(sym))
 				visitor.visitDefault(sym);
 		}, [&](auto& visitor, const ast::CallExpression &call) {
 			if (call.isSystemCall())
@@ -2909,88 +3294,6 @@ void finalize_special_nets(NetlistContext &netlist)
 	}
 }
 
-bool NetlistContext::is_blackbox(const ast::DefinitionSymbol &sym, slang::Diagnostic *why_blackbox)
-{
-	if (sym.cellDefine)
-		return true;
-
-	if (settings.blackboxed_modules.contains(sym.name))
-		return true;
-
-	for (auto attr : sym.getParentScope()->getCompilation().getAttributes(sym)) {
-		if (attr->name == "blackbox"sv && !attr->getValue().isFalse()) {
-			if (why_blackbox) {
-				auto &note = why_blackbox->addNote(diag::NoteModuleBlackboxBecauseAttribute,
-													attr->location);
-				note << sym.name;
-			}
-			return true;
-		}
-	}
-
-	if (settings.empty_blackboxes.value_or(false)) {
-		if (why_blackbox) {
-			auto &note = why_blackbox->addNote(diag::NoteModuleBlackboxBecauseEmpty, sym.location);
-			note << sym.name;
-		}
-		return is_decl_empty_module(*sym.getSyntax());
-	}
-
-	return false;
-}
-
-bool NetlistContext::should_dissolve(const ast::InstanceSymbol &sym, slang::Diagnostic *why_not_dissolved)
-{
-	// blackboxes are never dissolved
-	if (sym.isModule() && is_blackbox(sym.body.getDefinition())) {
-		if (why_not_dissolved) {
-			auto &note = why_not_dissolved->addNote(diag::NoteModuleNotDissolvedBecauseBlackbox, sym.location);
-			note << sym.body.name;
-			// insert note about blackbox reason
-			is_blackbox(sym.body.getDefinition(), why_not_dissolved);
-		}
-		return false;
-	}
-
-	// interfaces are always dissolved
-	if (sym.isInterface())
-		return true;
-
-	// the rest depends on the hierarchy mode
-	switch (settings.hierarchy_mode()) {
-	case SynthesisSettings::NONE:
-		return true;
-	case SynthesisSettings::BEST_EFFORT: {
-		for (auto *conn : sym.getPortConnections()) {
-			switch (conn->port.kind) {
-			case ast::SymbolKind::Port:
-			case ast::SymbolKind::MultiPort:
-				break;
-			case ast::SymbolKind::InterfacePort:
-				if (!conn->getIfaceConn().second)
-					return true;
-				break;
-			default:
-				return true;
-				break;
-			}
-		}
-
-		if (!sym.isModule())
-			return true;
-
-		return false;
-		}
-	case SynthesisSettings::ALL:
-		if (why_not_dissolved) {
-			auto &note = why_not_dissolved->addNote(diag::NoteModuleNotDissolvedBecauseKeepHierarchy, sym.location);
-			note << sym.body.name;
-		}
-	default:
-		return false;
-	}
-}
-
 const ast::InstanceBodySymbol &NetlistContext::find_symbol_realm(const ast::Symbol &symbol)
 {
 	const ast::Scope *scope = symbol.getParentScope();
@@ -3001,7 +3304,7 @@ const ast::InstanceBodySymbol &NetlistContext::find_symbol_realm(const ast::Symb
 			auto parent = scope_symbol.as<ast::InstanceBodySymbol>().parentInstance;
 			log_assert(parent->getParentScope());
 			if (parent->getParentScope()->asSymbol().kind == ast::SymbolKind::Root
-					|| !should_dissolve(*parent)) {
+					|| !settings.should_dissolve(*parent)) {
 				return scope_symbol.as<ast::InstanceBodySymbol>();
 			} else {
 				scope = parent->getParentScope();
@@ -3051,10 +3354,10 @@ bool NetlistContext::check_hier_ref(const ast::ValueSymbol &symbol, slang::Sourc
 		if (!silent) {
 			if (&symbol_realm != &common) {
 				// emit diagnostic for boundary on the hierarchical path to the symbol
-				(void) should_dissolve(*symbol_realm.parentInstance, &diag);
+				(void) settings.should_dissolve(*symbol_realm.parentInstance, &diag);
 			} else {
 				// emit diagnostic for boundary on the hierarchical path to the expression
-				(void) should_dissolve(*realm.parentInstance, &diag);
+				(void) settings.should_dissolve(*realm.parentInstance, &diag);
 			}			
 		}
 		return false;
@@ -3095,17 +3398,21 @@ NetlistContext::NetlistContext(
 		RTLIL::Design *design,
 		SynthesisSettings &settings,
 		ast::Compilation &compilation,
-		const ast::InstanceSymbol &instance)
+		const ast::InstanceSymbol &instance,
+		RTLIL::IdString module_name)
 	: settings(settings), compilation(compilation), realm(instance.body), eval(*this)
 {
-	canvas = design->addModule(module_type_id(instance.body));
+	if (module_name.empty())
+		module_name = module_type_id(instance.body);
+	canvas = design->addModule(module_name);
 	transfer_attrs(*this, instance.body.getDefinition(), canvas);
 }
 
 NetlistContext::NetlistContext(
 		NetlistContext &other,
-		const ast::InstanceSymbol &instance)
-	: NetlistContext(other.canvas->design, other.settings, other.compilation, instance)
+		const ast::InstanceSymbol &instance,
+		RTLIL::IdString module_name)
+	: NetlistContext(other.canvas->design, other.settings, other.compilation, instance, module_name)
 {
 }
 
@@ -3383,7 +3690,12 @@ struct SlangFrontend : Frontend {
 			global_compilation = &(*compilation);
 			global_sourcemgr = compilation->getSourceManager();
 
-			HierarchyQueue hqueue;
+			ModuleNameResolver module_names(settings);
+			for (auto instance : compilation->getRoot().topInstances)
+				module_names.scan_instance(*instance, true);
+			module_names.finalize();
+
+			HierarchyQueue hqueue(module_names);
 			for (auto instance : compilation->getRoot().topInstances) {
 				if (instance->getDefinition().definitionKind == ast::DefinitionKind::Program) {
 					slang::Diagnostic program_diag(diag::ProgramUnsupported, instance->location);
@@ -3627,8 +3939,12 @@ struct TestSlangExprPass : Pass {
 		global_compilation = &(*compilation);
 		global_sourcemgr = compilation->getSourceManager();
 
-		HierarchyQueue dummy_queue;
-		NetlistContext netlist(d, settings, *compilation, *top);
+		ModuleNameResolver module_names(settings);
+		module_names.scan_instance(*top, true);
+		module_names.finalize();
+
+		HierarchyQueue dummy_queue(module_names);
+		NetlistContext netlist(d, settings, *compilation, *top, module_names.module_name(top->body));
 		PopulateNetlist populate(dummy_queue, netlist);
 		populate.add_internal_wires(top->body);
 

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -453,6 +453,9 @@ struct SynthesisSettings {
 	std::optional<bool> allow_dual_edge_ff;
 	std::optional<bool> no_synthesis_define;
 	std::optional<UdpHandleMode> udp_handling;
+	std::optional<std::string> ff_naming;
+	std::optional<std::string> ff_prefix;
+	std::optional<std::string> ff_suffix;
 	// pass std::less<> to enable transparent lookup
 	std::set<std::string, std::less<>> blackboxed_modules;
 	bool disable_instance_caching = false;
@@ -474,6 +477,26 @@ struct SynthesisSettings {
 
 	int unroll_limit() {
 		return unroll_limit_.value_or(4000);
+	}
+
+	std::string ff_naming_mode() {
+		return ff_naming.value_or("legacy");
+	}
+
+	std::string ff_naming_prefix() {
+		if (ff_prefix.has_value())
+			return ff_prefix.value();
+		if (ff_naming_mode() == "legacy")
+			return "$driver$";
+		return "";
+	}
+
+	std::string ff_naming_suffix() {
+		if (ff_suffix.has_value())
+			return ff_suffix.value();
+		if (ff_naming_mode() == "legacy")
+			return "";
+		return "_reg";
 	}
 
 	void addOptions(slang::CommandLine &cmdLine);
@@ -597,6 +620,9 @@ extern void export_blackbox_to_rtlil(NetlistContext &netlist, const ast::Instanc
 // naming.cc
 typedef std::pair<VariableChunk, std::string> NamedChunk;
 std::vector<NamedChunk> generate_subfield_names(VariableChunk chunk, const ast::Type *type);
+std::string format_scope_name_fragment(const ast::Scope *relative_to, const ast::Scope *scope);
+std::string format_signal_name_fragment(const ast::Scope *relative_to, const ast::ValueSymbol &symbol,
+		std::string_view suffix);
 
 // initialization.cc
 void evaluate_decl_initializers(NetlistContext &netlist);

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -454,8 +454,6 @@ struct SynthesisSettings {
 	std::optional<bool> no_synthesis_define;
 	std::optional<UdpHandleMode> udp_handling;
 	std::optional<std::string> ff_naming;
-	std::optional<std::string> ff_prefix;
-	std::optional<std::string> ff_suffix;
 	// pass std::less<> to enable transparent lookup
 	std::set<std::string, std::less<>> blackboxed_modules;
 	bool disable_instance_caching = false;
@@ -481,22 +479,6 @@ struct SynthesisSettings {
 
 	std::string ff_naming_mode() {
 		return ff_naming.value_or("legacy");
-	}
-
-	std::string ff_naming_prefix() {
-		if (ff_prefix.has_value())
-			return ff_prefix.value();
-		if (ff_naming_mode() == "legacy")
-			return "$driver$";
-		return "";
-	}
-
-	std::string ff_naming_suffix() {
-		if (ff_suffix.has_value())
-			return ff_suffix.value();
-		if (ff_naming_mode() == "legacy")
-			return "";
-		return "_reg";
 	}
 
 	void addOptions(slang::CommandLine &cmdLine);
@@ -620,9 +602,10 @@ extern void export_blackbox_to_rtlil(NetlistContext &netlist, const ast::Instanc
 // naming.cc
 typedef std::pair<VariableChunk, std::string> NamedChunk;
 std::vector<NamedChunk> generate_subfield_names(VariableChunk chunk, const ast::Type *type);
-std::string format_scope_name_fragment(const ast::Scope *relative_to, const ast::Scope *scope);
+std::string format_scope_name_fragment(const ast::Scope *relative_to, const ast::Scope *scope,
+		std::string_view sep="_"sv);
 std::string format_signal_name_fragment(const ast::Scope *relative_to, const ast::ValueSymbol &symbol,
-		std::string_view suffix);
+		std::string_view suffix, std::string_view sep="_"sv);
 
 // initialization.cc
 void evaluate_decl_initializers(NetlistContext &netlist);

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -435,6 +435,10 @@ public:
 SLANG_ENUM(UdpHandleMode, UDP_HANDL)
 #undef UDP_HANDL
 
+#define MODULE_UNIQUIFY(x) x(instance) x(param)
+SLANG_ENUM(ModuleUniquifyMode, MODULE_UNIQUIFY)
+#undef MODULE_UNIQUIFY
+
 struct SynthesisSettings {
 	std::optional<bool> dump_ast;
 	std::optional<bool> no_proc;
@@ -454,6 +458,7 @@ struct SynthesisSettings {
 	std::optional<bool> no_synthesis_define;
 	std::optional<UdpHandleMode> udp_handling;
 	std::optional<std::string> ff_naming;
+	std::optional<ModuleUniquifyMode> module_uniquify;
 	// pass std::less<> to enable transparent lookup
 	std::set<std::string, std::less<>> blackboxed_modules;
 	bool disable_instance_caching = false;
@@ -480,6 +485,13 @@ struct SynthesisSettings {
 	std::string ff_naming_mode() {
 		return ff_naming.value_or("legacy");
 	}
+
+	ModuleUniquifyMode module_uniquify_mode() {
+		return module_uniquify.value_or(ModuleUniquifyMode::instance);
+	}
+
+	bool is_blackbox(const ast::DefinitionSymbol &sym, slang::Diagnostic *why_blackbox=nullptr);
+	bool should_dissolve(const ast::InstanceSymbol &sym, slang::Diagnostic *why_not_dissolved=nullptr);
 
 	void addOptions(slang::CommandLine &cmdLine);
 };
@@ -539,10 +551,12 @@ struct NetlistContext : RTLILBuilder, public DiagnosticIssuer {
 	NetlistContext(RTLIL::Design *design,
 		SynthesisSettings &settings,
 		ast::Compilation &compilation,
-		const ast::InstanceSymbol &instance);
+		const ast::InstanceSymbol &instance,
+		RTLIL::IdString module_name = {});
 
 	NetlistContext(NetlistContext &other,
-		const ast::InstanceSymbol &instance);
+		const ast::InstanceSymbol &instance,
+		RTLIL::IdString module_name = {});
 
 	~NetlistContext();
 
@@ -552,9 +566,6 @@ struct NetlistContext : RTLILBuilder, public DiagnosticIssuer {
 	Yosys::pool<const ast::Symbol *> detected_memories;
 	bool is_inferred_memory(const ast::Symbol &symbol);
 	bool is_inferred_memory(const ast::Expression &expr);
-
-	bool is_blackbox(const ast::DefinitionSymbol &sym, slang::Diagnostic *why_blackbox=nullptr);
-	bool should_dissolve(const ast::InstanceSymbol &sym, slang::Diagnostic *why_not_dissolved=nullptr);
 
 	// Find the "realm" for the given symbol, i.e. the containing instance body
 	// which is not getting dissolved during netlist emission. If we are fully flattening

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ set(ALL_TESTS
     various/issue50.ys
     various/mem_inference.ys
     various/meminit.ys
+    various/module_uniquify.ys
     various/pragmas.ys
     various/regress.ys
     various/stringattrs.ys

--- a/tests/various/flop_naming.ys
+++ b/tests/various/flop_naming.ys
@@ -55,3 +55,178 @@ select -assert-any t:$*ff* c:$driver$a[1].field1 %i
 select -assert-any t:$*ff* c:$driver$a[1].field0 %i
 select -assert-any t:$*ff* c:$driver$a[0].field1 %i
 select -assert-any t:$*ff* c:$driver$a[0].field0 %i
+
+design -reset
+read_slang --ff-naming signal <<EOF
+module top(input logic clk);
+	typedef struct packed {
+		logic valid;
+		struct packed {
+			logic [1:0] opcode;
+		} header;
+	} packet_t;
+
+	packet_t state_q, state_d;
+
+	always_ff @(posedge clk)
+		state_q <= state_d;
+endmodule
+EOF
+select -assert-count 2 t:$*ff*
+select -assert-any t:$*ff* c:state_q_valid_reg %i
+select -assert-any t:$*ff* c:state_q_header_opcode_reg %i
+
+design -reset
+read_slang --ff-naming signal <<EOF
+module top(input logic clk);
+	logic [3:0] state_q, state_d;
+
+	always_ff @(posedge clk)
+		state_q[2] <= state_d[2];
+endmodule
+EOF
+select -assert-count 1 t:$*ff*
+select -assert-any t:$*ff* n:*state_q_2_reg %i
+
+design -reset
+read_slang --ff-naming signal <<EOF
+module top(input logic clk);
+	logic [7:0] state_q, state_d;
+
+	always_ff @(posedge clk)
+		state_q[5:2] <= state_d[5:2];
+endmodule
+EOF
+select -assert-count 1 t:$*ff*
+select -assert-any t:$*ff* c:state_q_5downto2_reg %i
+
+design -reset
+read_slang --ff-naming auto <<EOF
+module top(input logic clk);
+	logic state_q, state_d;
+
+	always_ff @(posedge clk) begin : state_update
+		state_q <= state_d;
+	end
+endmodule
+EOF
+select -assert-count 1 t:$*ff*
+select -assert-any t:$*ff* c:state_update_reg %i
+
+design -reset
+read_slang --ff-naming auto <<EOF
+module top(input logic clk);
+	logic a_q, a_d, b_q, b_d;
+
+	always_ff @(posedge clk) begin : regs
+		a_q <= a_d;
+		b_q <= b_d;
+	end
+endmodule
+EOF
+select -assert-count 2 t:$*ff*
+select -assert-any t:$*ff* c:regs_a_q_reg %i
+select -assert-any t:$*ff* c:regs_b_q_reg %i
+
+design -reset
+read_slang --ff-naming auto <<EOF
+module top(input logic clk);
+	genvar i;
+	for (i = 0; i < 2; i++) begin : gen_gpios
+		logic serial_q, serial_d;
+		always_ff @(posedge clk) begin : capture
+			serial_q <= serial_d;
+		end
+	end
+endmodule
+EOF
+select -assert-count 2 t:$*ff*
+select -assert-any t:$*ff* c:gen_gpios_0_capture_reg %i
+select -assert-any t:$*ff* c:gen_gpios_1_capture_reg %i
+
+design -reset
+read_slang --ff-naming signal <<EOF
+module top(input logic clk);
+	genvar i;
+	for (i = 0; i < 2; i++) begin : gen_gpios
+		logic serial_q, serial_d;
+		always_ff @(posedge clk)
+			serial_q <= serial_d;
+	end
+endmodule
+EOF
+select -assert-count 2 t:$*ff*
+select -assert-any t:$*ff* c:gen_gpios_0_serial_q_reg %i
+select -assert-any t:$*ff* c:gen_gpios_1_serial_q_reg %i
+
+design -reset
+read_slang --ff-naming signal <<EOF
+module top(input logic clk, input logic d);
+	always_ff @(posedge clk) begin
+		static logic local_q;
+		local_q <= d;
+	end
+endmodule
+EOF
+select -assert-count 1 t:$*ff*
+select -assert-any t:$*ff* n:*__*_local_q_reg %i
+
+design -reset
+read_slang --ff-naming auto <<EOF
+module top(input logic clk);
+	logic state_reg, state_d;
+
+	always_ff @(posedge clk)
+		state_reg <= state_d;
+endmodule
+EOF
+select -assert-count 1 t:$*ff*
+select -assert-any t:$*ff* n:state_reg* %i
+
+design -reset
+read_slang --ff-naming signal --ff-suffix _ff <<EOF
+module top(input logic clk);
+	logic state_q, state_d;
+
+	always_ff @(posedge clk)
+		state_q <= state_d;
+endmodule
+EOF
+select -assert-count 1 t:$*ff*
+select -assert-any t:$*ff* c:state_q_ff %i
+
+design -reset
+read_slang --ff-naming signal --ff-prefix dbg_ <<EOF
+module top(input logic clk);
+	logic dbg_state_q, state_d;
+
+	always_ff @(posedge clk)
+		dbg_state_q <= state_d;
+endmodule
+EOF
+select -assert-count 1 t:$*ff*
+select -assert-any t:$*ff* n:*dbg_state_q_reg %i
+
+design -reset
+read_slang --ff-naming legacy --ff-prefix dbg_ <<EOF
+module top(input logic clk);
+	logic state_q, state_d;
+
+	always_ff @(posedge clk)
+		state_q <= state_d;
+endmodule
+EOF
+select -assert-count 1 t:$*ff*
+select -assert-any t:$*ff* c:dbg_state_q %i
+
+design -reset
+read_slang --ff-naming legacy --ff-suffix _ff <<EOF
+module top(input logic clk);
+	logic state_q, state_d;
+
+	always_ff @(posedge clk)
+		state_q <= state_d;
+endmodule
+EOF
+select -assert-count 1 t:$*ff*
+select -assert-any t:$*ff* n:*\$driver$state_q_ff %i

--- a/tests/various/flop_naming.ys
+++ b/tests/various/flop_naming.ys
@@ -145,6 +145,56 @@ select -assert-any t:$*ff* c:gen_gpios_0_capture_reg %i
 select -assert-any t:$*ff* c:gen_gpios_1_capture_reg %i
 
 design -reset
+read_slang --ff-naming {sep=-}{scope}{proc_auto}-ff <<EOF
+module top(input logic clk);
+	genvar i;
+	for (i = 0; i < 2; i++) begin : gen_gpios
+		logic serial_q, serial_d;
+		always_ff @(posedge clk) begin : capture
+			serial_q <= serial_d;
+		end
+	end
+endmodule
+EOF
+select -assert-count 2 t:$*ff*
+select -assert-any t:$*ff* c:gen_gpios-0-capture-ff %i
+select -assert-any t:$*ff* c:gen_gpios-1-capture-ff %i
+
+design -reset
+read_slang --ff-naming {sep=_}{scope}{proc_auto}_reg <<EOF
+module top(input logic clk);
+	genvar i;
+	for (i = 0; i < 2; i++) begin : gen_gpios
+		logic serial_q, serial_d;
+		always_ff @(posedge clk)
+			serial_q <= serial_d;
+	end
+endmodule
+EOF
+select -assert-count 2 t:$*ff*
+select -assert-any t:$*ff* c:gen_gpios_0_serial_q_reg %i
+select -assert-any t:$*ff* c:gen_gpios_1_serial_q_reg %i
+
+design -reset
+read_slang --ff-naming {sep=_}{scope}{proc_auto}_reg <<EOF
+module top(input logic clk);
+	genvar i;
+	for (i = 0; i < 2; i++) begin : gen_gpios
+		logic a_q, a_d, b_q, b_d;
+		always_ff @(posedge clk) begin : capture
+			a_q <= a_d;
+			b_q <= b_d;
+		end
+	end
+endmodule
+EOF
+select -assert-count 4 t:$*ff*
+select -assert-any t:$*ff* c:gen_gpios_0_capture_a_q_reg %i
+select -assert-any t:$*ff* c:gen_gpios_0_capture_b_q_reg %i
+select -assert-any t:$*ff* c:gen_gpios_1_capture_a_q_reg %i
+select -assert-any t:$*ff* c:gen_gpios_1_capture_b_q_reg %i
+
+design -reset
 read_slang --ff-naming signal <<EOF
 module top(input logic clk);
 	genvar i;
@@ -169,7 +219,7 @@ module top(input logic clk, input logic d);
 endmodule
 EOF
 select -assert-count 1 t:$*ff*
-select -assert-any t:$*ff* n:*__*_local_q_reg %i
+select -assert-any t:$*ff* n:*_local_q_reg %i
 
 design -reset
 read_slang --ff-naming auto <<EOF
@@ -181,10 +231,10 @@ module top(input logic clk);
 endmodule
 EOF
 select -assert-count 1 t:$*ff*
-select -assert-any t:$*ff* n:state_reg* %i
+select -assert-any t:$*ff* n:state_reg_reg* %i
 
 design -reset
-read_slang --ff-naming signal --ff-suffix _ff <<EOF
+read_slang --ff-naming {sep=_}{signal}_ff <<EOF
 module top(input logic clk);
 	logic state_q, state_d;
 
@@ -196,19 +246,19 @@ select -assert-count 1 t:$*ff*
 select -assert-any t:$*ff* c:state_q_ff %i
 
 design -reset
-read_slang --ff-naming signal --ff-prefix dbg_ <<EOF
+read_slang --ff-naming {sep=-}{scope}{signal}-ff <<EOF
 module top(input logic clk);
-	logic dbg_state_q, state_d;
+	logic [7:0] state_q, state_d;
 
 	always_ff @(posedge clk)
-		dbg_state_q <= state_d;
+		state_q[5:2] <= state_d[5:2];
 endmodule
 EOF
 select -assert-count 1 t:$*ff*
-select -assert-any t:$*ff* n:*dbg_state_q_reg %i
+select -assert-any t:$*ff* c:state_q-5downto2-ff %i
 
 design -reset
-read_slang --ff-naming legacy --ff-prefix dbg_ <<EOF
+read_slang --ff-naming dbg_{sep=_}{signal}_reg <<EOF
 module top(input logic clk);
 	logic state_q, state_d;
 
@@ -217,16 +267,65 @@ module top(input logic clk);
 endmodule
 EOF
 select -assert-count 1 t:$*ff*
-select -assert-any t:$*ff* c:dbg_state_q %i
+select -assert-any t:$*ff* c:dbg_state_q_reg %i
 
 design -reset
-read_slang --ff-naming legacy --ff-suffix _ff <<EOF
+read_slang --ff-naming {sep=_}{scope}{proc}{signal}_reg <<EOF
 module top(input logic clk);
 	logic state_q, state_d;
 
-	always_ff @(posedge clk)
+	always_ff @(posedge clk) begin : regs
 		state_q <= state_d;
+	end
 endmodule
 EOF
 select -assert-count 1 t:$*ff*
-select -assert-any t:$*ff* n:*\$driver$state_q_ff %i
+select -assert-any t:$*ff* c:regs_state_q_reg %i
+
+design -reset
+read_slang --ff-naming {sep=_}{scope}{proc}{signal}_reg <<EOF
+module top(input logic clk);
+	genvar i;
+	for (i = 0; i < 2; i++) begin : gen_gpios
+		logic serial_q, serial_d;
+		always_ff @(posedge clk)
+			serial_q <= serial_d;
+	end
+endmodule
+EOF
+select -assert-count 2 t:$*ff*
+select -assert-any t:$*ff* c:gen_gpios_0_serial_q_reg %i
+select -assert-any t:$*ff* c:gen_gpios_1_serial_q_reg %i
+
+design -reset
+read_slang --ff-naming {sep=_}{scope}{proc}{signal}_reg <<EOF
+module top(input logic clk);
+	genvar i;
+	for (i = 0; i < 2; i++) begin : gen_gpios
+		logic serial_q, serial_d;
+		always_ff @(posedge clk) begin : capture
+			serial_q <= serial_d;
+		end
+	end
+endmodule
+EOF
+select -assert-count 2 t:$*ff*
+select -assert-any t:$*ff* c:gen_gpios_0_capture_serial_q_reg %i
+select -assert-any t:$*ff* c:gen_gpios_1_capture_serial_q_reg %i
+
+design -reset
+read_slang --ff-naming auto <<EOF
+module top(input logic clk, input logic rst_n, input logic [7:0] d);
+	logic [7:0] q;
+
+	always_ff @(posedge clk or negedge rst_n) begin : regs
+		if (!rst_n)
+			q[0] <= 1'b0;
+		else
+			q <= d;
+	end
+endmodule
+EOF
+select -assert-count 2 t:$*ff*
+select -assert-any t:$*ff* c:regs_q_0_reg %i
+select -assert-any t:$*ff* c:regs_q_7downto1_reg %i

--- a/tests/various/module_uniquify.ys
+++ b/tests/various/module_uniquify.ys
@@ -1,0 +1,111 @@
+read_slang --keep-hierarchy --module-uniquify param <<EOF
+module child #(parameter int WIDTH = 8) (output logic [WIDTH-1:0] y);
+	assign y = 0;
+endmodule
+
+module top(output logic [7:0] a, output logic [7:0] b);
+	child #(.WIDTH(8)) u0(a);
+	child #(.WIDTH(8)) u1(b);
+endmodule
+EOF
+
+cd child
+cd top
+
+design -reset
+
+read_slang --keep-hierarchy <<EOF
+module child #(parameter int WIDTH = 8) (output logic [WIDTH-1:0] y);
+	assign y = 0;
+endmodule
+
+module top(output logic [7:0] a, output logic [7:0] b);
+	child #(.WIDTH(8)) u0(a);
+	child #(.WIDTH(8)) u1(b);
+endmodule
+EOF
+
+cd child$top.u0
+cd child$top.u1
+cd top
+
+design -reset
+
+read_slang --keep-hierarchy --module-uniquify param <<EOF
+module child #(parameter int WIDTH = 8) (output logic [WIDTH-1:0] y);
+	assign y = 0;
+endmodule
+
+module top(output logic [7:0] a, output logic [15:0] b);
+	child #(.WIDTH(8)) u0(a);
+	child #(.WIDTH(16)) u1(b);
+endmodule
+EOF
+
+cd child__WIDTH_8
+cd child__WIDTH_16
+cd top
+
+design -reset
+
+read_slang --keep-hierarchy --module-uniquify param <<EOF
+module child_int #(parameter int VALUE = 0) (output logic y);
+	assign y = 0;
+endmodule
+
+module child_logic #(parameter logic [3:0] VALUE = 0) (output logic y);
+	assign y = 0;
+endmodule
+
+module top(output logic a, output logic b, output logic c, output logic d);
+	child_int #(.VALUE(32'd8)) u0(a);
+	child_int #(.VALUE(-1)) u1(b);
+	child_logic #(.VALUE(4'b1010)) u2(c);
+	child_logic #(.VALUE(4'b10x1)) u3(d);
+endmodule
+EOF
+
+cd child_int__VALUE_8
+cd child_int__VALUE_m1
+cd child_logic__VALUE_10
+cd child_logic__VALUE_b10x1
+cd top
+
+design -reset
+
+read_slang --keep-hierarchy --module-uniquify param <<EOF
+module child_type #(parameter type dtype = logic [3:0]) (output dtype y);
+	assign y = '0;
+endmodule
+
+module top(output logic [33:0] a, output logic [7:0] b);
+	child_type #(.dtype(logic [33:0])) u0(a);
+	child_type #(.dtype(logic [7:0])) u1(b);
+endmodule
+EOF
+
+cd child_type__dtype_logic_33downto0
+cd child_type__dtype_logic_7downto0
+cd top
+
+design -reset
+
+read_slang --best-effort-hierarchy --module-uniquify param <<EOF
+module leaf #(parameter int WIDTH = 8) (output logic [WIDTH-1:0] y);
+	assign y = 0;
+endmodule
+
+module wrap(output logic [7:0] a, output logic [15:0] b);
+	leaf #(.WIDTH(8)) u0(a);
+	leaf #(.WIDTH(16)) u1(b);
+endmodule
+
+module top(output logic [7:0] a, output logic [15:0] b);
+	wrap w(a, b);
+endmodule
+EOF
+
+cd wrap
+cd leaf__WIDTH_8
+cd leaf__WIDTH_16
+cd top


### PR DESCRIPTION
This is on-top of the FF-naming in #305 for my own sanity while testing things on our end.

This adds `--module-uniquify` which changes how the modules in the hierarchy are preserved when using `--keep-hierarchy` or `--best-effort-hierarchy`:
-   `--module-uniquify instance` the current behavior where every instance of the module is uniquified (meaning all module instantiations are unique)
-  ` --module-uniquify param` new behavior where every unique parametrization is uniquified (meaning some instantiations are shared if hey use the same parametrization)

The `param` mode also needs a new naming scheme for its modules which you can see from a few examples in Croc. It tries to writeout the parameters explicitly in the name but once the string gets too long it will switch to using a hash instead.
```
sync__STAGES_2__ResetValue_0
sync__STAGES_3__ResetValue_0

counter__WIDTH_4__STICKY_OVERFLOW_0
counter__WIDTH_5__STICKY_OVERFLOW_0
counter__WIDTH_16__STICKY_OVERFLOW_0
  
fifo_v3__FALL_THROUGH_0__DATA_WIDTH_32__DEPTH_2__dtype_logic_33downto0__ADDR_DEPTH_1
fifo_v3__FALL_THROUGH_0__DATA_WIDTH_8__DEPTH_16__dtype_logic_7downto0__ADDR_DEPTH_4

addr_decode__p505912c7
cdc_2phase_clearable__p86ddbee9
```

As I understand it, I am already respecting interfaces and possible port compatibility but there are cases I am not covering with any tests or have given enough thought to.
