### PR TITLE
Add Bazel build for slang.so

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+third_party/fmt/support/bazel

--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -1,0 +1,26 @@
+name: Bazel build
+on: [push, pull_request]
+jobs:
+  bazel:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      # TODO: remove the local-registry override once the yosys 0.62.bcr.2
+      # module lands in BCR (bazelbuild/bazel-central-registry#8636).
+      - name: Patch BCR with in-flight yosys 0.62.bcr.2
+        run: |
+          git clone --filter=blob:none https://github.com/bazelbuild/bazel-central-registry.git "$HOME/bcr"
+          git -C "$HOME/bcr" fetch origin pull/8636/head:pr-8636
+          git -C "$HOME/bcr" checkout pr-8636
+      - uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+      - name: Build
+        run: |
+          bazel build //... \
+            --registry=file://$HOME/bcr \
+            --registry=https://bcr.bazel.build

--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -7,13 +7,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      # TODO: remove the local-registry override once the yosys 0.62.bcr.2
-      # module lands in BCR (bazelbuild/bazel-central-registry#8636).
-      - name: Patch BCR with in-flight yosys 0.62.bcr.2
-        run: |
-          git clone --filter=blob:none https://github.com/bazelbuild/bazel-central-registry.git "$HOME/bcr"
-          git -C "$HOME/bcr" fetch origin pull/8636/head:pr-8636
-          git -C "$HOME/bcr" checkout pr-8636
       - uses: bazel-contrib/setup-bazel@0.15.0
         with:
           bazelisk-cache: true
@@ -21,6 +14,4 @@ jobs:
           repository-cache: true
       - name: Build
         run: |
-          bazel build //... \
-            --registry=file://$HOME/bcr \
-            --registry=https://bcr.bazel.build
+          bazel build //...

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 !/.git*
 !.gitkeep
 !/.clang-format
+!/.bazelignore

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,7 +9,6 @@ if needed.
 
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
-load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
 
 package(
@@ -230,6 +229,7 @@ cc_library(
         "-std=c++20",
         "-Wno-unused-parameter",
     ],
+    visibility = ["//src/yosys_plugin:__pkg__"],
     deps = [
         ":slang",
         "@yosys//:hdrs",
@@ -237,8 +237,3 @@ cc_library(
     alwayslink = True,
 )
 
-cc_shared_library(
-    name = "slang.so",
-    shared_lib_name = "slang.so",
-    deps = [":yosys_slang_plugin"],
-)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,6 +24,22 @@ license(
     license_text = "LICENSE",
 )
 
+# Bundled slang and fmt are vendored under their own (MIT) licenses.
+
+license(
+    name = "license_slang",
+    package_name = "slang",
+    license_kinds = ["@rules_license//licenses/spdx:MIT"],
+    license_text = "third_party/slang/LICENSE",
+)
+
+license(
+    name = "license_fmt",
+    package_name = "fmt",
+    license_kinds = ["@rules_license//licenses/spdx:MIT"],
+    license_text = "third_party/fmt/LICENSE",
+)
+
 # Version of the slang library tracked in third_party/slang.
 # Bump when the submodule is updated. SLANG_VERSION_PATCH/HASH are
 # normally derived from `git describe`; left as 0/"unknown" here since
@@ -136,6 +152,7 @@ cc_library(
         "third_party/fmt/src/os.cc",
     ],
     hdrs = glob(["third_party/fmt/include/fmt/*.h"]),
+    applicable_licenses = [":license_fmt"],
     copts = [
         "-fPIC",
         "-std=c++20",
@@ -188,6 +205,7 @@ cc_library(
         ":slang/syntax/SyntaxFwd.h",
         ":slang/syntax/SyntaxKind.h",
     ],
+    applicable_licenses = [":license_slang"],
     copts = [
         "-fPIC",
         "-std=c++20",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,217 @@
+"""yosys-slang plugin: builds slang.so against @yosys//:hdrs.
+
+slang and fmt are vendored as git submodules under third_party/. The
+diagnostic_gen.py / syntax_gen.py codegen mirrors what slang's own
+cmake runs at build time. SLANG_VERSION_PATCH/HASH are stubbed (cmake
+derives them from `git describe`); refine with a workspace-status hook
+if needed.
+"""
+
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+# --- Generated export header (static build = no-op) ---
+
+genrule(
+    name = "slang_export_h",
+    outs = ["slang/slang_export.h"],
+    cmd = """cat > $@ << 'HEADER'
+#pragma once
+#define SLANG_EXPORT
+#define SLANG_NO_EXPORT
+HEADER""",
+)
+
+genrule(
+    name = "slang_version_cpp",
+    srcs = ["third_party/slang/source/util/VersionInfo.cpp.in"],
+    outs = ["VersionInfo.cpp"],
+    cmd = """sed \
+        -e 's/@SLANG_VERSION_MAJOR@/10/' \
+        -e 's/@SLANG_VERSION_MINOR@/0/' \
+        -e 's/@SLANG_VERSION_PATCH@/0/' \
+        -e 's/@SLANG_VERSION_HASH@/unknown/' \
+        $(location third_party/slang/source/util/VersionInfo.cpp.in) > $@""",
+)
+
+# --- Code generation for slang ---
+
+genrule(
+    name = "slang_diag_gen",
+    srcs = [
+        "third_party/slang/scripts/diagnostic_gen.py",
+        "third_party/slang/scripts/diagnostics.txt",
+    ] + glob([
+        "third_party/slang/source/**/*.cpp",
+        "third_party/slang/include/slang/**/*.h",
+    ]),
+    outs = [
+        "DiagCode.cpp",
+        "slang/diagnostics/AllDiags.h",
+        "slang/diagnostics/AnalysisDiags.h",
+        "slang/diagnostics/CompilationDiags.h",
+        "slang/diagnostics/ConstEvalDiags.h",
+        "slang/diagnostics/DeclarationsDiags.h",
+        "slang/diagnostics/ExpressionsDiags.h",
+        "slang/diagnostics/GeneralDiags.h",
+        "slang/diagnostics/LexerDiags.h",
+        "slang/diagnostics/LookupDiags.h",
+        "slang/diagnostics/MetaDiags.h",
+        "slang/diagnostics/NumericDiags.h",
+        "slang/diagnostics/ParserDiags.h",
+        "slang/diagnostics/PreprocessorDiags.h",
+        "slang/diagnostics/StatementsDiags.h",
+        "slang/diagnostics/SysFuncsDiags.h",
+        "slang/diagnostics/TypesDiags.h",
+    ],
+    cmd = """
+        python3 $(location third_party/slang/scripts/diagnostic_gen.py) \
+            --outDir $(@D) \
+            --srcDir $$(dirname $(location third_party/slang/source/parsing/Parser.cpp))/.. \
+            --incDir $$(dirname $(location third_party/slang/include/slang/diagnostics/Diagnostics.h))/.. \
+            --diagnostics $(location third_party/slang/scripts/diagnostics.txt)
+    """,
+)
+
+genrule(
+    name = "slang_syntax_gen",
+    srcs = glob(["third_party/slang/scripts/*.txt"]) + [
+        "third_party/slang/scripts/syntax_gen.py",
+    ],
+    outs = [
+        "AllSyntax.cpp",
+        "KnownSystemName.cpp",
+        "SyntaxClone.cpp",
+        "TokenKind.cpp",
+        "slang/syntax/AllSyntax.h",
+        "slang/syntax/CSTJsonVisitorGen.h",
+        "slang/syntax/SyntaxFwd.h",
+        "slang/syntax/SyntaxKind.h",
+        "slang/parsing/TokenKind.h",
+        "slang/parsing/KnownSystemName.h",
+    ],
+    cmd = """
+        SCRIPTS=$$(dirname $(location third_party/slang/scripts/syntax_gen.py)) && \
+        python3 $(location third_party/slang/scripts/syntax_gen.py) \
+            --dir $(@D) \
+            --syntax $$SCRIPTS/syntax.txt
+    """,
+)
+
+# --- fmt (vendored in third_party/fmt) ---
+
+cc_library(
+    name = "fmt",
+    srcs = [
+        "third_party/fmt/src/format.cc",
+        "third_party/fmt/src/os.cc",
+    ],
+    hdrs = glob(["third_party/fmt/include/fmt/*.h"]),
+    copts = [
+        "-fPIC",
+        "-std=c++20",
+    ],
+    includes = ["third_party/fmt/include"],
+)
+
+# --- slang (vendored in third_party/slang) ---
+
+cc_library(
+    name = "slang",
+    srcs = glob(
+        ["third_party/slang/source/**/*.cpp"],
+    ) + glob(
+        ["third_party/slang/source/**/*.h"],
+    ) + [
+        ":AllSyntax.cpp",
+        ":DiagCode.cpp",
+        ":KnownSystemName.cpp",
+        ":SyntaxClone.cpp",
+        ":TokenKind.cpp",
+        ":VersionInfo.cpp",
+    ],
+    hdrs = glob([
+        "third_party/slang/include/**/*.h",
+        "third_party/slang/external/**/*.hpp",  # buildifier: disable=external-path
+        "third_party/slang/external/ieee1800/**",  # buildifier: disable=external-path
+    ]) + [
+        ":slang/diagnostics/AllDiags.h",
+        ":slang/diagnostics/AnalysisDiags.h",
+        ":slang/diagnostics/CompilationDiags.h",
+        ":slang/diagnostics/ConstEvalDiags.h",
+        ":slang/diagnostics/DeclarationsDiags.h",
+        ":slang/diagnostics/ExpressionsDiags.h",
+        ":slang/diagnostics/GeneralDiags.h",
+        ":slang/diagnostics/LexerDiags.h",
+        ":slang/diagnostics/LookupDiags.h",
+        ":slang/diagnostics/MetaDiags.h",
+        ":slang/diagnostics/NumericDiags.h",
+        ":slang/diagnostics/ParserDiags.h",
+        ":slang/diagnostics/PreprocessorDiags.h",
+        ":slang/diagnostics/StatementsDiags.h",
+        ":slang/diagnostics/SysFuncsDiags.h",
+        ":slang/diagnostics/TypesDiags.h",
+        ":slang/parsing/KnownSystemName.h",
+        ":slang/parsing/TokenKind.h",
+        ":slang/slang_export.h",
+        ":slang/syntax/AllSyntax.h",
+        ":slang/syntax/CSTJsonVisitorGen.h",
+        ":slang/syntax/SyntaxFwd.h",
+        ":slang/syntax/SyntaxKind.h",
+    ],
+    copts = [
+        "-fPIC",
+        "-std=c++20",
+        "-Wno-unused-parameter",
+    ],
+    defines = [
+        "SLANG_BOOST_SINGLE_HEADER",
+        "SLANG_VERSION_MAJOR=10",
+        "SLANG_VERSION_MINOR=0",
+        "SLANG_VERSION_PATCH=0",
+        'SLANG_VERSION_HASH=\\"unknown\\"',
+    ],
+    includes = [
+        "third_party/slang/external",
+        "third_party/slang/include",
+        "third_party/slang/source/ast/builtins",
+    ],
+    deps = [":fmt"],
+)
+
+genrule(
+    name = "version_h",
+    outs = ["version.h"],
+    cmd = """cat > $@ << 'HEADER'
+#pragma once
+#define YOSYS_SLANG_REVISION "unknown"
+#define SLANG_REVISION "unknown"
+HEADER""",
+)
+
+# --- yosys-slang plugin (shared library) ---
+
+cc_binary(
+    name = "slang.so",
+    srcs = glob([
+        "src/*.cc",
+        "src/*.h",
+    ]) + [":version.h"],
+    copts = [
+        "-fPIC",
+        "-std=c++20",
+        "-Wno-unused-parameter",
+    ],
+    defines = [
+        'YOSYS_SLANG_REVISION=\\"unknown\\"',
+        'SLANG_REVISION=\\"unknown\\"',
+    ],
+    linkopts = ["-shared"],
+    linkshared = True,
+    deps = [
+        ":slang",
+        "@yosys//:hdrs",
+    ],
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,10 +7,36 @@ derives them from `git describe`); refine with a workspace-status hook
 if needed.
 """
 
-load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
+load("@rules_license//rules:license.bzl", "license")
 
-package(default_visibility = ["//visibility:public"])
+package(
+    default_applicable_licenses = [":license"],
+    default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
+)
+
+license(
+    name = "license",
+    package_name = "yosys-slang",
+    license_kinds = ["@rules_license//licenses/spdx:ISC"],
+    license_text = "LICENSE",
+)
+
+# Version of the slang library tracked in third_party/slang.
+# Bump when the submodule is updated. SLANG_VERSION_PATCH/HASH are
+# normally derived from `git describe`; left as 0/"unknown" here since
+# the submodule is checked out detached.
+SLANG_VERSION_MAJOR = 10
+SLANG_VERSION_MINOR = 0
+SLANG_VERSION_PATCH = 0
+SLANG_VERSION_HASH = "unknown"
+
+# yosys-slang's own revision string is taken from MODULE.bazel's
+# version field (set by the BCR submitter at release time).
+YOSYS_SLANG_REVISION = module_version() or "unknown"
 
 # --- Generated export header (static build = no-op) ---
 
@@ -24,16 +50,16 @@ genrule(
 HEADER""",
 )
 
-genrule(
+expand_template(
     name = "slang_version_cpp",
-    srcs = ["third_party/slang/source/util/VersionInfo.cpp.in"],
-    outs = ["VersionInfo.cpp"],
-    cmd = """sed \
-        -e 's/@SLANG_VERSION_MAJOR@/10/' \
-        -e 's/@SLANG_VERSION_MINOR@/0/' \
-        -e 's/@SLANG_VERSION_PATCH@/0/' \
-        -e 's/@SLANG_VERSION_HASH@/unknown/' \
-        $(location third_party/slang/source/util/VersionInfo.cpp.in) > $@""",
+    out = "VersionInfo.cpp",
+    substitutions = {
+        "@SLANG_VERSION_MAJOR@": str(SLANG_VERSION_MAJOR),
+        "@SLANG_VERSION_MINOR@": str(SLANG_VERSION_MINOR),
+        "@SLANG_VERSION_PATCH@": str(SLANG_VERSION_PATCH),
+        "@SLANG_VERSION_HASH@": SLANG_VERSION_HASH,
+    },
+    template = "third_party/slang/source/util/VersionInfo.cpp.in",
 )
 
 # --- Code generation for slang ---
@@ -67,12 +93,13 @@ genrule(
         "slang/diagnostics/TypesDiags.h",
     ],
     cmd = """
-        python3 $(location third_party/slang/scripts/diagnostic_gen.py) \
+        $(PYTHON3) $(location third_party/slang/scripts/diagnostic_gen.py) \
             --outDir $(@D) \
             --srcDir $$(dirname $(location third_party/slang/source/parsing/Parser.cpp))/.. \
             --incDir $$(dirname $(location third_party/slang/include/slang/diagnostics/Diagnostics.h))/.. \
             --diagnostics $(location third_party/slang/scripts/diagnostics.txt)
     """,
+    toolchains = ["@rules_python//python:current_py_toolchain"],
 )
 
 genrule(
@@ -94,10 +121,11 @@ genrule(
     ],
     cmd = """
         SCRIPTS=$$(dirname $(location third_party/slang/scripts/syntax_gen.py)) && \
-        python3 $(location third_party/slang/scripts/syntax_gen.py) \
+        $(PYTHON3) $(location third_party/slang/scripts/syntax_gen.py) \
             --dir $(@D) \
             --syntax $$SCRIPTS/syntax.txt
     """,
+    toolchains = ["@rules_python//python:current_py_toolchain"],
 )
 
 # --- fmt (vendored in third_party/fmt) ---
@@ -166,13 +194,7 @@ cc_library(
         "-std=c++20",
         "-Wno-unused-parameter",
     ],
-    defines = [
-        "SLANG_BOOST_SINGLE_HEADER",
-        "SLANG_VERSION_MAJOR=10",
-        "SLANG_VERSION_MINOR=0",
-        "SLANG_VERSION_PATCH=0",
-        'SLANG_VERSION_HASH=\\"unknown\\"',
-    ],
+    defines = ["SLANG_BOOST_SINGLE_HEADER"],
     includes = [
         "third_party/slang/external",
         "third_party/slang/include",
@@ -181,20 +203,24 @@ cc_library(
     deps = [":fmt"],
 )
 
-genrule(
+expand_template(
     name = "version_h",
-    outs = ["version.h"],
-    cmd = """cat > $@ << 'HEADER'
-#pragma once
-#define YOSYS_SLANG_REVISION "unknown"
-#define SLANG_REVISION "unknown"
-HEADER""",
+    out = "version.h",
+    substitutions = {
+        "@YOSYS_SLANG_REVISION@": YOSYS_SLANG_REVISION,
+        "@SLANG_REVISION@": "{}.{}.{}".format(
+            SLANG_VERSION_MAJOR,
+            SLANG_VERSION_MINOR,
+            SLANG_VERSION_PATCH,
+        ),
+    },
+    template = "src/version.h.in",
 )
 
 # --- yosys-slang plugin (shared library) ---
 
-cc_binary(
-    name = "slang.so",
+cc_library(
+    name = "yosys_slang_plugin",
     srcs = glob([
         "src/*.cc",
         "src/*.h",
@@ -204,14 +230,15 @@ cc_binary(
         "-std=c++20",
         "-Wno-unused-parameter",
     ],
-    defines = [
-        'YOSYS_SLANG_REVISION=\\"unknown\\"',
-        'SLANG_REVISION=\\"unknown\\"',
-    ],
-    linkopts = ["-shared"],
-    linkshared = True,
     deps = [
         ":slang",
         "@yosys//:hdrs",
     ],
+    alwayslink = True,
+)
+
+cc_shared_library(
+    name = "slang.so",
+    shared_lib_name = "slang.so",
+    deps = [":yosys_slang_plugin"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,4 +8,7 @@ module(
 
 # yosys 0.62.bcr.2 is the first release that exports :hdrs for plugins.
 bazel_dep(name = "yosys", version = "0.62.bcr.2")
-bazel_dep(name = "rules_cc", version = "0.2.4")
+bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "rules_python", version = "2.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "rules_license", version = "1.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,11 @@
+"""yosys-slang plugin: SystemVerilog frontend for yosys via slang."""
+
+module(
+    name = "yosys-slang",
+    version = "0.0.0",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+# yosys 0.62.bcr.2 is the first release that exports :hdrs for plugins.
+bazel_dep(name = "yosys", version = "0.62.bcr.2")
+bazel_dep(name = "rules_cc", version = "0.2.4")

--- a/src/yosys_plugin/BUILD.bazel
+++ b/src/yosys_plugin/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
+
+cc_shared_library(
+    name = "slang.so",
+    shared_lib_name = "slang.so",
+    deps = ["//:yosys_slang_plugin"],
+)


### PR DESCRIPTION
Builds the plugin against `@yosys//:hdrs` (yosys 0.62.bcr.2 onwards).
slang and fmt stay vendored as the existing submodules; the
`diagnostic_gen.py` / `syntax_gen.py` codegen runs in genrules,
mirroring what cmake does. `SLANG_VERSION_PATCH`/`HASH` are stubbed —
the cmake build derives them from `git describe` and the same hook
can be wired in here later.

Smoke-tested with bazel 8.6.0 against an in-flight yosys 0.62.bcr.2
fork (https://github.com/bazelbuild/bazel-central-registry/pull/8636);
build is cache-clean in ~40s.

Together with that yosys 0.62.bcr.2 BCR module this is enough to add
yosys-slang to the registry — the only piece still missing is a
release tarball with submodules vendored. Happy to follow up with a
GitHub release workflow that runs `git submodule update --init
--recursive` before tarring, if you'd like to be the BCR submitter.