### PR TITLE
Bazel: make slang.so publicly visible

### DIFF
--- a/src/yosys_plugin/BUILD.bazel
+++ b/src/yosys_plugin/BUILD.bazel
@@ -3,5 +3,6 @@ load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 cc_shared_library(
     name = "slang.so",
     shared_lib_name = "slang.so",
+    visibility = ["//visibility:public"],
     deps = ["//:yosys_slang_plugin"],
 )


### PR DESCRIPTION
## Summary

`cc_shared_library` defaults to package-private visibility, so external Bazel modules can't depend on `@yosys-slang//src/yosys_plugin:slang.so` — currently the only artifact downstream actually consumes from this repo.

This blocks the natural follow-up to #310: an external module bundling the plugin into yosys's `share/` dir for plugin loading. One-line fix to set `//visibility:public` on the shared library.

## Test plan

- [x] Local `bazelisk build //src/yosys_plugin:slang.so` still succeeds.
- [x] An external project depending on `@yosys-slang//src/yosys_plugin:slang.so` now resolves (verified in The-OpenROAD-Project/OpenROAD#10237 follow-up).