### PR TITLE
Return const references from wire cache

### DIFF
--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -2661,7 +2661,7 @@ bool is_special_net(const ast::Symbol &symbol)
 		&& is_special_net_type(symbol.as<ast::NetSymbol>().netType);
 }
 
-RTLIL::SigSpec NetlistContext::add_wire(const ast::ValueSymbol &symbol)
+const RTLIL::SigSpec& NetlistContext::add_wire(const ast::ValueSymbol &symbol)
 {
 	auto &type = symbol.getType();
 
@@ -2687,7 +2687,7 @@ RTLIL::SigSpec NetlistContext::add_wire(const ast::ValueSymbol &symbol)
 			special_net_symbols.push_back(&net);
 		}
 	}
-	return sig;
+	return wire_cache[&symbol];
 }
 
 void finalize_special_nets(NetlistContext &netlist)
@@ -2869,7 +2869,7 @@ bool NetlistContext::check_hier_ref(const ast::ValueSymbol &symbol, slang::Sourc
 	return true;
 }
 
-RTLIL::SigSpec NetlistContext::wire(const ast::Symbol &symbol)
+const RTLIL::SigSpec& NetlistContext::wire(const ast::Symbol &symbol)
 {
 	auto it = wire_cache.find(&symbol);
 	if (it == wire_cache.end())

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -500,8 +500,8 @@ struct NetlistContext : RTLILBuilder, public DiagnosticIssuer {
 	std::string id(const ast::ValueSymbol &sym);
 	std::string hdlname(const ast::Symbol &sym);
 
-	RTLIL::SigSpec add_wire(const ast::ValueSymbol &sym);
-	RTLIL::SigSpec wire(const ast::Symbol &sym);
+	const RTLIL::SigSpec& add_wire(const ast::ValueSymbol &sym);
+	const RTLIL::SigSpec& wire(const ast::Symbol &sym);
 	RTLIL::SigSpec convert_static(VariableBits bits);
 
 	struct Memory {


### PR DESCRIPTION
Copying RTLil::SigSpec turns out to potentially be very expensive for wide signals. When accessing the copy via operator[], Yosys internally calls SigSpec::unpack(), which iterates over all bits in the signal. This can potentially lead to O(n^2) behaviour when a copy is implicitly created for every bit in a signal, such as in VariableState::evaluate().

This was enough to cause a runtime difference of ~45s versus not finishing overnight for designs that happened to have a few extremely wide signals, on the order of >100KiB in multidimensional arrays.