### PR TITLE
Support overlapped implication in concurrent assertions

### DIFF
--- a/src/sva.cc
+++ b/src/sva.cc
@@ -16,6 +16,27 @@
 
 namespace slang_frontend {
 
+static const ast::Expression *get_simple_assertion_expr(
+		NetlistContext &netlist, const ast::AssertionExpr &assertion_expr,
+		slang::SourceRange fallback_source_range)
+{
+	slang::SourceRange source_range = assertion_expr.syntax ?
+		assertion_expr.syntax->sourceRange() : fallback_source_range;
+
+	if (!ast::SimpleAssertionExpr::isKind(assertion_expr.kind)) {
+		netlist.add_diag(diag::UnsupportedSVAFeature, source_range);
+		return nullptr;
+	}
+
+	auto &simple_expr = assertion_expr.as<ast::SimpleAssertionExpr>();
+	if (simple_expr.repetition.has_value()) {
+		netlist.add_diag(diag::RepetitionsUnsupported, source_range);
+		return nullptr;
+	}
+
+	return &simple_expr.expr;
+}
+
 // Process a 'concurrent assertion'
 //
 // Any top level clocking expressions have been stripped. Clocking is part
@@ -47,25 +68,43 @@ void process_sva_property(const ast::ConcurrentAssertionStatement &statement,
 		source_range = expr->syntax ? expr->syntax->sourceRange() : statement.sourceRange;
 	}
 
-	if (!ast::SimpleAssertionExpr::isKind(expr->kind)) {
-		netlist.add_diag(diag::UnsupportedSVAFeature, source_range);
-		return;
-	}
-
-	auto &simple_assertion = expr->as<ast::SimpleAssertionExpr>();
-
-	// We don't support repetition in simple assertions
-	if (simple_assertion.repetition.has_value()) {
-		netlist.add_diag(diag::RepetitionsUnsupported, source_range);
-		return;
-	}
-
 	std::string flavor;
 	switch (statement.assertionKind) {
 	case ast::AssertionKind::Assert:        flavor = "assert"; break;
 	case ast::AssertionKind::Assume:        flavor = "assume"; break;
 	case ast::AssertionKind::CoverProperty: flavor = "cover"; break;
 	default:                                netlist.add_diag(diag::AssertionUnsupported, statement.sourceRange); return;
+	}
+
+	RTLIL::SigSpec a;
+	if (ast::SimpleAssertionExpr::isKind(expr->kind)) {
+		auto simple_expr = get_simple_assertion_expr(netlist, *expr, source_range);
+		if (!simple_expr)
+			return;
+		a = netlist.ReduceBool(procedural.eval.sva(*simple_expr));
+	} else if (ast::BinaryAssertionExpr::isKind(expr->kind)) {
+		auto &binary_expr = expr->as<ast::BinaryAssertionExpr>();
+		if (binary_expr.op != ast::BinaryAssertionOperator::OverlappedImplication) {
+			netlist.add_diag(diag::UnsupportedSVAFeature, source_range);
+			return;
+		}
+
+		auto lhs_expr = get_simple_assertion_expr(netlist, binary_expr.left, source_range);
+		auto rhs_expr = get_simple_assertion_expr(netlist, binary_expr.right, source_range);
+		if (!lhs_expr || !rhs_expr)
+			return;
+
+		RTLIL::SigSpec antecedent = netlist.ReduceBool(procedural.eval.sva(*lhs_expr));
+		RTLIL::SigSpec consequent = netlist.ReduceBool(procedural.eval.sva(*rhs_expr));
+		if (statement.assertionKind == ast::AssertionKind::CoverProperty) {
+			// Cover only non-vacuous successes of the implication.
+			a = netlist.LogicAnd(antecedent, consequent);
+		} else {
+			a = netlist.LogicOr(netlist.LogicNot(antecedent), consequent);
+		}
+	} else {
+		netlist.add_diag(diag::UnsupportedSVAFeature, source_range);
+		return;
 	}
 
 	RTLIL::IdString cell_name;
@@ -76,8 +115,6 @@ void process_sva_property(const ast::ConcurrentAssertionStatement &statement,
 	} else {
 		cell_name = netlist.new_id();
 	}
-
-	RTLIL::SigSpec a = netlist.ReduceBool(procedural.eval.sva(simple_assertion.expr));
 
 	auto cell = netlist.canvas->addCell(cell_name, ID($check));
 	procedural.set_effects_trigger(cell);

--- a/tests/various/concurrent_assert.sv
+++ b/tests/various/concurrent_assert.sv
@@ -36,3 +36,18 @@ module m_labeled_concurrent(input clk, input rst_n, input [7:0] data);
 	// Labeled concurrent assertion
 	my_concurrent_assert: assert property (@(posedge clk) disable iff (!rst_n) data != 8'hFF);
 endmodule
+
+module m_overlapped_implication(input clk, input a, input b);
+	// a |-> b is equivalent to !a || b in the same clock tick
+	assert property (@(posedge clk) a |-> b);
+endmodule
+
+module m_overlapped_implication_disable_iff(input clk, input rst_n, input a, input b);
+	// Overlapped implication with disable iff
+	assert property (@(posedge clk) disable iff (!rst_n) a |-> b);
+endmodule
+
+module m_overlapped_implication_cover(input clk, input a, input b);
+	// Cover with overlapped implication
+	cover property (@(posedge clk) a |-> b);
+endmodule

--- a/tests/various/concurrent_assert.ys
+++ b/tests/various/concurrent_assert.ys
@@ -1,7 +1,7 @@
 read_slang concurrent_assert.sv
 
 # Test basic concurrent assertions exist
-select -assert-count 10 t:$check
+select -assert-count 13 t:$check
 
 # Test m_concurrent_assert: posedge clk, no disable iff
 select -assert-count 1 m_concurrent_assert/t:$check
@@ -35,3 +35,20 @@ select -assert-count 1 m_multiple_concurrent/t:$check r:TRG_POLARITY=1'0 %i
 # Test m_labeled_concurrent: labeled assertion
 select -assert-count 1 m_labeled_concurrent/t:$check
 select -assert-count 1 m_labeled_concurrent/t:$check n:*my_concurrent_assert %i
+
+# Test m_overlapped_implication: a |-> b (assert, posedge clk)
+select -assert-count 1 m_overlapped_implication/t:$check
+select -assert-count 1 m_overlapped_implication/t:$check r:FLAVOR=assert %i
+select -assert-count 1 m_overlapped_implication/t:$check r:TRG_POLARITY=1'1 %i
+select -assert-count 1 m_overlapped_implication/t:$logic_or
+
+# Test m_overlapped_implication_disable_iff: a |-> b with disable iff
+select -assert-count 1 m_overlapped_implication_disable_iff/t:$check
+select -assert-count 1 m_overlapped_implication_disable_iff/t:$check r:FLAVOR=assert %i
+select -assert-count 1 m_overlapped_implication_disable_iff/t:$logic_or
+
+# Test m_overlapped_implication_cover: cover with non-vacuous a |-> b
+select -assert-count 1 m_overlapped_implication_cover/t:$check
+select -assert-count 1 m_overlapped_implication_cover/t:$check r:FLAVOR=cover %i
+select -assert-count 1 m_overlapped_implication_cover/t:$logic_and
+select -assert-count 0 m_overlapped_implication_cover/t:$logic_or


### PR DESCRIPTION
## Summary

- Add support for simple overlapped implication (`a |-> b`) in concurrent SVA properties.
- Lower assert/assume implications to `!antecedent || consequent`.
- Lower cover implications to non-vacuous success, `antecedent && consequent`.
- Add regression tests for plain, `disable iff`, and cover-property cases.

Assisted-by: Codex:ChatGPT-5.5

## Testing
`./tests/run.sh` passed.