### PR TITLE
Bazel: anchor slang_diag_gen $(location ...) on diagnostic_gen.py

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -108,10 +108,11 @@ genrule(
         "slang/diagnostics/TypesDiags.h",
     ],
     cmd = """
+        SCRIPTS=$$(dirname $(location third_party/slang/scripts/diagnostic_gen.py)) && \
         $(PYTHON3) $(location third_party/slang/scripts/diagnostic_gen.py) \
             --outDir $(@D) \
-            --srcDir $$(dirname $(location third_party/slang/source/parsing/Parser.cpp))/.. \
-            --incDir $$(dirname $(location third_party/slang/include/slang/diagnostics/Diagnostics.h))/.. \
+            --srcDir $$SCRIPTS/../source \
+            --incDir $$SCRIPTS/../include/slang \
             --diagnostics $(location third_party/slang/scripts/diagnostics.txt)
     """,
     toolchains = ["@rules_python//python:current_py_toolchain"],


### PR DESCRIPTION
## Problem

`slang_diag_gen` derives `--srcDir` / `--incDir` from
`$(location third_party/slang/source/parsing/Parser.cpp)` and
`$(location third_party/slang/include/slang/diagnostics/Diagnostics.h)`.
Both labels only reach the rule via the `glob(["third_party/slang/source/**/*.cpp", "third_party/slang/include/slang/**/*.h"])`.
When that glob comes up short — e.g. `init_submodules` transiently
incomplete after a fresh fetch in CI — Bazel errors at analysis time:

```
label '...:third_party/slang/source/parsing/Parser.cpp' in $(location)
expression is not a declared prerequisite of this rule
```

…before any action runs. Hit downstream when consuming yosys-slang via
`git_override(init_submodules = True)` in another project's Bazel
workspace; the failure is sticky once the cached external-repo state is
short, and confusing because the file *does* exist on disk after a
clean re-fetch.

## Fix

Anchor both directories on `$(location ...diagnostic_gen.py)` — an
explicit, non-glob `src` — instead. Same `dirname $(location ...)/...`
pattern the sibling `slang_syntax_gen` genrule already uses.

## Test

`bazel build //src/yosys_plugin:slang.so` from a clean checkout still
produces all 18 expected `slang_diag_gen` outputs and links `slang.so`
end-to-end (verified in a downstream workspace consuming this fork via
`git_override`).