### PR TITLE
 Avoid dissolving instances with inout ports

### DIFF
--- a/src/diag.cc
+++ b/src/diag.cc
@@ -105,6 +105,7 @@ DiagCode NoteModuleBlackboxBecauseAttribute(DiagSubsystem::Netlist, 1051);
 DiagCode NoteModuleBlackboxBecauseEmpty(DiagSubsystem::Netlist, 1052);
 DiagCode NoteModuleNotDissolvedBecauseBlackbox(DiagSubsystem::Netlist, 1053);
 DiagCode NoteModuleNotDissolvedBecauseKeepHierarchy(DiagSubsystem::Netlist, 1054);
+DiagCode NoteModuleNotDissolvedBecauseInOut(DiagSubsystem::Netlist, 1084);
 DiagCode BlockingAssignmentAfterNonblocking(DiagSubsystem::Netlist, 1055);
 DiagCode NonblockingAssignmentAfterBlocking(DiagSubsystem::Netlist, 1056);
 DiagCode NotePreviousAssignment(DiagSubsystem::Netlist, 1057);
@@ -273,6 +274,8 @@ void setup_messages(slang::DiagnosticEngine &engine)
 	engine.setSeverity(NoteModuleNotDissolvedBecauseBlackbox, DiagnosticSeverity::Note);
 	engine.setMessage(NoteModuleNotDissolvedBecauseKeepHierarchy, "instance of module '{}' will not dissolve because of '--keep-hierarchy' option");
 	engine.setSeverity(NoteModuleNotDissolvedBecauseKeepHierarchy, DiagnosticSeverity::Note);
+	engine.setMessage(NoteModuleNotDissolvedBecauseInOut, "instance of module '{}' will not dissolve because the module has an inout port");
+	engine.setSeverity(NoteModuleNotDissolvedBecauseInOut, DiagnosticSeverity::Note);
 
 	engine.setMessage(BlockingAssignmentAfterNonblocking, "blocking assignment to variable '{}' is not supported after previous non-blocking assignment");
 	engine.setSeverity(BlockingAssignmentAfterNonblocking, DiagnosticSeverity::Error);

--- a/src/diag.h
+++ b/src/diag.h
@@ -61,6 +61,7 @@ extern slang::DiagCode NoteModuleBlackboxBecauseAttribute;
 extern slang::DiagCode NoteModuleBlackboxBecauseEmpty;
 extern slang::DiagCode NoteModuleNotDissolvedBecauseBlackbox;
 extern slang::DiagCode NoteModuleNotDissolvedBecauseKeepHierarchy;
+extern slang::DiagCode NoteModuleNotDissolvedBecauseInOut;
 extern slang::DiagCode BlockingAssignmentAfterNonblocking;
 extern slang::DiagCode NonblockingAssignmentAfterBlocking;
 extern slang::DiagCode NotePreviousAssignment;

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -3092,6 +3092,31 @@ bool NetlistContext::should_dissolve(const ast::InstanceSymbol &sym, slang::Diag
 	if (sym.isInterface())
 		return true;
 
+	if (sym.isModule()) {
+		for (auto *conn : sym.getPortConnections()) {
+			if (conn->port.kind == ast::SymbolKind::Port) {
+				auto &port = conn->port.as<ast::PortSymbol>();
+				if (port.direction != ast::ArgumentDirection::InOut)
+					continue;
+				if (why_not_dissolved) {
+					auto &note = why_not_dissolved->addNote(diag::NoteModuleNotDissolvedBecauseInOut, port.location);
+					note << sym.body.name;
+				}
+				return false;
+			}
+			if (conn->port.kind == ast::SymbolKind::MultiPort) {
+				auto &port = conn->port.as<ast::MultiPortSymbol>();
+				if (port.direction != ast::ArgumentDirection::InOut)
+					continue;
+				if (why_not_dissolved) {
+					auto &note = why_not_dissolved->addNote(diag::NoteModuleNotDissolvedBecauseInOut, port.location);
+					note << sym.body.name;
+				}
+				return false;
+			}
+		}
+	}
+
 	// the rest depends on the hierarchy mode
 	switch (settings.hierarchy_mode()) {
 	case SynthesisSettings::NONE:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ set(ALL_TESTS
     various/intf_array_naming.ys
     various/intf_w_hierarchy.ys
     various/issue142.ys
+    various/issue143.ys
     various/issue208.ys
     various/issue227.ys
     various/issue240.ys

--- a/tests/various/hierref_error.ys
+++ b/tests/various/hierref_error.ys
@@ -48,3 +48,17 @@ module top();
 	wire g = i1.w;
 endmodule
 EOF
+
+design -reset
+test_slangdiag -expect "hierarchical reference across preserved module boundary"
+read_slang --keep-hierarchy <<EOF
+module submod(inout pad, output out);
+	assign out = pad;
+	wire w = pad;
+endmodule
+
+module top(inout pad, output out);
+	submod i1(.pad(pad), .out(out));
+	wire g = i1.w;
+endmodule
+EOF

--- a/tests/various/issue143.ys
+++ b/tests/various/issue143.ys
@@ -1,0 +1,26 @@
+read_slang <<EOF
+module iocell_opendrain (
+  inout  wire  pad,
+  input  logic oe,
+  output logic in
+);
+  assign in  = pad;
+  assign pad = oe ? 1'b0 : 1'bz;
+endmodule
+
+module top (
+  inout  wire  scl,
+  input  logic drive_low,
+  output logic sampled
+);
+  iocell_opendrain io_scl (
+    .pad(scl),
+    .oe (drive_low),
+    .in (sampled)
+  );
+endmodule
+EOF
+
+hierarchy -top top
+proc
+check


### PR DESCRIPTION
yosys-slang currently cannot lower inlined bidirectional port connections correctly, instead it errors during netlist conversion.