### PR TITLE
Allow type parameters on blackboxed modules (silent no-op on export)

### DIFF
--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -2129,7 +2129,16 @@ public:
 					cell->setParam(RTLIL::escape_id(std::string(symbol.name)), *converted);
 				}
 			}, [&](auto&, const ast::TypeParameterSymbol &symbol) {
-				netlist.add_diag(diag::BboxTypeParameter, symbol.location);
+				// Pwrtaur Phase 76 — Bug #2 patch.
+				// Type parameters on blackboxed modules are compile-
+				// time only; yosys's RTL representation doesn't need
+				// them. Silently ignore instead of erroring so that
+				// type-parametric stubs (e.g. cva6_hpdcache_subsystem
+				// for CVA6 corpus-validate) can act as blackboxes
+				// without yosys-slang refusing the module. The real
+				// downstream Cell carries only value parameters via
+				// the ParameterSymbol branch above.
+				(void) symbol;
 			}, [&](auto&, const ast::InstanceSymbol&) {
 				// no-op
 			}));


### PR DESCRIPTION
## Summary

`UninstantiatedDefSymbol::handle()` walks the body of a blackboxed module to copy its parameter list onto the downstream RTLIL Cell. Today it emits `BboxTypeParameter` ("blackbox cannot have a type parameter") on any `TypeParameterSymbol` it finds, making it impossible to author a type-parametric stub for an unknown SV module.

This PR silently ignores `TypeParameterSymbol` on blackbox export. Type parameters are compile-time SystemVerilog metadata; yosys's RTLIL representation doesn't carry them anyway. The downstream Cell still receives all *value* parameters via the existing `ParameterSymbol` branch.

## Motivation

In real designs, a common pattern is to author a stub for an unknown module so the rest of the design can elaborate. CVA6 (Ariane) has this surface:

```sv
// cva6.sv:1452 — call site
cva6_hpdcache_subsystem #(
    .icache_areq_t(icache_areq_t),
    /* 19 more type parameter bindings */
    .NumPorts(NumPorts)
) i_hpdcache (...);
```

A stub matching that call site must carry the same `parameter type` declarations, but `--blackboxed-module=cva6_hpdcache_subsystem` then trips `BboxTypeParameter`. There's no workaround that lives outside yosys-slang.

## Repro

```sv
module stub
#( parameter type icache_areq_t = logic )
( /* ports */ );
  // body...
endmodule
```

```
yosys -m slang -p "read_slang --blackboxed-module=stub stub.sv"
# => stub.sv:2:20: error: blackbox cannot have a type parameter
```

After this PR: silently accepted.

## Related

Companion to a slang-side PR (MikePopoloski/slang) that narrows the `mustBeChecker` heuristic so empty port connections to unknown modules no longer flip the checker-classification path. Either PR can land independently; together they unblock CVA6 elaboration via `read_slang`.

Discovered while building the Pwrtaur power-minimization tool's corpus-validate harness against the four major permissive RISC-V cores (picoRV32, CV32E40P, Snitch, CVA6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)