### PR TITLE
Simplify bitwise RHS expression cells

### DIFF
--- a/src/builder.cc
+++ b/src/builder.cc
@@ -323,6 +323,27 @@ int convert(RTLIL::SigBit bit)
 }
 }; // namespace ThreeValued
 
+static SigSpec bitwise_identity_result(SigSpec sig)
+{
+	std::vector<int> z_offsets;
+	int offset = 0;
+
+	for (const RTLIL::SigChunk &chunk : sig.chunks()) {
+		if (!chunk.is_wire()) {
+			for (int i = 0; i < chunk.width; i++) {
+				if (chunk.data[i] == RTLIL::Sz)
+					z_offsets.push_back(offset + i);
+			}
+		}
+		offset += chunk.width;
+	}
+
+	for (int z_offset : z_offsets)
+		sig[z_offset] = RTLIL::Sx;
+
+	return sig;
+}
+
 SigSpec RTLILBuilder::Biop(
 		IdString op, SigSpec a, SigSpec b, bool a_signed, bool b_signed, int y_width)
 {
@@ -396,6 +417,27 @@ SigSpec RTLILBuilder::Biop(
 			SigSpec ret = {RTLIL::S1};
 			ret.extend_u0(y_width);
 			return ret;
+		}
+	}
+
+	if (op.in(ID($and), ID($or)) && a.size() == y_width && b.size() == y_width) {
+		if (a == b)
+			return bitwise_identity_result(a);
+
+		if (op == ID($and)) {
+			if (a.is_fully_zero() || b.is_fully_zero())
+				return SigSpec(RTLIL::S0, y_width);
+			if (a.is_fully_ones())
+				return bitwise_identity_result(b);
+			if (b.is_fully_ones())
+				return bitwise_identity_result(a);
+		} else {
+			if (a.is_fully_ones() || b.is_fully_ones())
+				return SigSpec(RTLIL::S1, y_width);
+			if (a.is_fully_zero())
+				return bitwise_identity_result(b);
+			if (b.is_fully_zero())
+				return bitwise_identity_result(a);
 		}
 	}
 

--- a/src/procedural.cc
+++ b/src/procedural.cc
@@ -135,18 +135,12 @@ void ProceduralContext::copy_case_tree_into(RTLIL::CaseRule &rule)
 VariableBits ProceduralContext::all_driven()
 {
 	VariableBits all_driven;
-	for (auto pair : vstate.visible_assignments) {
-		all_driven.append(pair.first);
+	for (auto chunk : vstate.assigned_chunks()) {
+		if (chunk.variable.kind == Variable::Static)
+			all_driven.append(VariableBits(chunk));
 	}
 
-	all_driven.sort_and_unify();
-
-	VariableBits all_driven_filtered;
-	for (auto chunk : all_driven.chunks())
-		if (chunk.variable.kind == Variable::Static)
-			all_driven_filtered.append(VariableBits(chunk));
-
-	return all_driven_filtered;
+	return all_driven;
 }
 
 RTLIL::SigBit ProceduralContext::case_enable()

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -5,6 +5,7 @@
 // Distributed under the terms of the ISC license, see LICENSE
 //
 // clang-format off
+#include <algorithm>
 #include <vector>
 
 #include "slang/ast/ASTVisitor.h"
@@ -461,37 +462,263 @@ const ast::InstanceBodySymbol &get_instance_body(SynthesisSettings &settings, co
 }
 
 using VariableState = ProceduralContext::VariableState;
+using StateSegment = VariableState::Segment;
+using StateSegmentStore = VariableState::SegmentStore;
+
+// Segment helpers maintain sorted, non-overlapping per-variable ranges.
+// append_segment() also coalesces adjacent ranges after callers split or
+// overwrite existing segments.
+static void append_segment(std::vector<StateSegment> &segments, StateSegment segment)
+{
+	if (segment.bitwidth() == 0)
+		return;
+
+	if (!segments.empty() && segments.back().end() == segment.base) {
+		segments.back().value.append(segment.value);
+		return;
+	}
+
+	log_assert(segments.empty() || segments.back().end() < segment.base);
+	segments.push_back(segment);
+}
+
+static std::vector<StateSegment>::const_iterator first_possible_segment(
+		const std::vector<StateSegment> &segments, uint64_t base)
+{
+	return std::lower_bound(segments.begin(), segments.end(), base,
+			[](const StateSegment &segment, uint64_t value) { return segment.end() <= value; });
+}
+
+static void set_segment(std::vector<StateSegment> &segments, uint64_t base, RTLIL::SigSpec value)
+{
+	if (value.empty())
+		return;
+
+	uint64_t end = base + value.size();
+
+	if (segments.empty() || segments.back().end() <= base) {
+		append_segment(segments, {base, value});
+		return;
+	}
+
+	std::vector<StateSegment> updated;
+	updated.reserve(segments.size() + 1);
+	bool inserted = false;
+
+	for (const auto &segment : segments) {
+		if (segment.end() <= base) {
+			append_segment(updated, segment);
+			continue;
+		}
+
+		if (segment.base >= end) {
+			if (!inserted) {
+				append_segment(updated, {base, value});
+				inserted = true;
+			}
+			append_segment(updated, segment);
+			continue;
+		}
+
+		if (segment.base < base) {
+			append_segment(updated, {
+					segment.base,
+					segment.value.extract(0, (int)(base - segment.base))
+			});
+		}
+
+		if (!inserted) {
+			append_segment(updated, {base, value});
+			inserted = true;
+		}
+
+		if (segment.end() > end) {
+			append_segment(updated, {
+					end,
+					segment.value.extract((int)(end - segment.base), (int)(segment.end() - end))
+			});
+		}
+	}
+
+	if (!inserted)
+		append_segment(updated, {base, value});
+
+	segments.swap(updated);
+}
+
+static void erase_segment(std::vector<StateSegment> &segments, uint64_t base, uint64_t width)
+{
+	if (width == 0 || segments.empty())
+		return;
+
+	uint64_t end = base + width;
+	if (segments.back().end() <= base)
+		return;
+
+	std::vector<StateSegment> updated;
+	updated.reserve(segments.size());
+
+	for (const auto &segment : segments) {
+		if (segment.end() <= base || segment.base >= end) {
+			append_segment(updated, segment);
+			continue;
+		}
+
+		if (segment.base < base) {
+			append_segment(updated, {
+					segment.base,
+					segment.value.extract(0, (int)(base - segment.base))
+			});
+		}
+
+		if (segment.end() > end) {
+			append_segment(updated, {
+					end,
+					segment.value.extract((int)(end - segment.base), (int)(segment.end() - end))
+			});
+		}
+	}
+
+	segments.swap(updated);
+}
+
+static RTLIL::SigSpec value_from_store(const StateSegmentStore &store,
+		Variable variable, uint64_t base, uint64_t width, bool require_present)
+{
+	RTLIL::SigSpec ret;
+	uint64_t end = base + width;
+	auto segments_it = store.by_variable.find(variable);
+	if (segments_it == store.by_variable.end()) {
+		log_assert(!require_present);
+		return RTLIL::SigSpec(RTLIL::Sm, (int)width);
+	}
+
+	const auto &segments = segments_it->second;
+	auto segment_it = first_possible_segment(segments, base);
+	uint64_t pos = base;
+
+	while (pos < end) {
+		if (segment_it == segments.end() || segment_it->base >= end) {
+			log_assert(!require_present);
+			ret.append(RTLIL::SigSpec(RTLIL::Sm, (int)(end - pos)));
+			break;
+		}
+
+		if (pos < segment_it->base) {
+			log_assert(!require_present);
+			ret.append(RTLIL::SigSpec(RTLIL::Sm, (int)(segment_it->base - pos)));
+			pos = segment_it->base;
+			continue;
+		}
+
+		log_assert(pos < segment_it->end());
+		uint64_t width_here = std::min(end - pos, segment_it->end() - pos);
+		ret.append(segment_it->value.extract((int)(pos - segment_it->base), (int)width_here));
+		pos += width_here;
+
+		if (pos == segment_it->end())
+			segment_it++;
+	}
+
+	log_assert(ret.size() == (int)width);
+	return ret;
+}
+
+static void append_static_value(
+		RTLIL::SigSpec &ret, NetlistContext &netlist, Variable variable,
+		uint64_t base, uint64_t width)
+{
+	if (width == 0)
+		return;
+
+	if (variable.kind == Variable::Dummy) {
+		ret.append(RTLIL::SigSpec(RTLIL::Sx, (int)width));
+		return;
+	}
+
+	log_assert(variable.kind == Variable::Static);
+	ret.append(netlist.wire(*variable.get_symbol()).extract((int)base, (int)width));
+}
+
+static void record_undo(VariableState &state, const VariableChunk &chunk)
+{
+	auto &undo_segments = state.revert.by_variable[chunk.variable];
+	std::vector<std::pair<uint64_t, uint64_t>> gaps;
+
+	// Save only spans not already in the undo log. Branch restore is
+	// first-touch based, so later writes must not replace the parent value.
+	uint64_t end = chunk.base + chunk.length;
+	uint64_t pos = chunk.base;
+	auto segment_it = first_possible_segment(undo_segments, chunk.base);
+
+	while (pos < end) {
+		if (segment_it == undo_segments.end() || segment_it->base >= end) {
+			gaps.push_back({pos, end - pos});
+			break;
+		}
+
+		if (pos < segment_it->base) {
+			uint64_t gap_end = std::min(end, segment_it->base);
+			gaps.push_back({pos, gap_end - pos});
+			pos = gap_end;
+			continue;
+		}
+
+		log_assert(pos < segment_it->end());
+		pos = std::min(end, segment_it->end());
+		segment_it++;
+	}
+
+	for (auto [gap_base, gap_width] : gaps) {
+		set_segment(undo_segments, gap_base,
+				value_from_store(state.visible_assignments, chunk.variable, gap_base, gap_width, false));
+	}
+}
+
+static void restore_previous_segment(VariableState &state, Variable variable, StateSegment previous)
+{
+	int pos = 0;
+	auto &segments = state.visible_assignments.by_variable[variable];
+
+	// Undo values use Sm for bits that were absent in the parent state. Split
+	// those runs so restore erases them instead of writing sentinel bits back.
+	while (pos < previous.value.size()) {
+		bool absent = previous.value[pos] == RTLIL::Sm;
+		int start = pos;
+		while (pos < previous.value.size() && (previous.value[pos] == RTLIL::Sm) == absent)
+			pos++;
+
+		uint64_t base = previous.base + start;
+		int width = pos - start;
+		if (absent)
+			erase_segment(segments, base, width);
+		else
+			set_segment(segments, base, previous.value.extract(start, width));
+	}
+
+	if (segments.empty())
+		state.visible_assignments.by_variable.erase(variable);
+}
 
 void VariableState::set(VariableBits lhs, RTLIL::SigSpec value)
 {
 	log_assert(lhs.bitwidth() == (uint64_t)value.size());
 
-	for (uint64_t i = 0; i < lhs.bitwidth(); i++) {
-		VariableBit bit = lhs[i];
-
-		if (!revert.count(bit)) {
-			if (visible_assignments.count(bit))
-				revert[bit] = visible_assignments.at(bit);
-			else
-				revert[bit] = RTLIL::Sm;
-		}
-
-		visible_assignments[bit] = value[i];
+	for (auto [base, size, chunk] : lhs.chunk_spans()) {
+		record_undo(*this, chunk);
+		set_segment(visible_assignments.by_variable[chunk.variable], chunk.base,
+				value.extract((int)base, (int)size));
 	}
 }
 
 RTLIL::SigSpec VariableState::evaluate(NetlistContext &netlist, VariableBits vbits)
 {
 	RTLIL::SigSpec ret;
-	for (auto vbit : vbits) {
-		if (vbit.variable.kind == Variable::Dummy) {
-			ret.append(RTLIL::Sx);
-		} else if (visible_assignments.count(vbit)) {
-			ret.append(visible_assignments.at(vbit));
-		} else {
-			log_assert(vbit.variable.kind == Variable::Static);
-			ret.append(netlist.wire(*vbit.variable.get_symbol())[(int)vbit.offset]);
-		}
+	for (auto chunk : vbits.chunks()) {
+		if (chunk.variable.kind == Variable::Dummy)
+			ret.append(RTLIL::SigSpec(RTLIL::Sx, (int)chunk.length));
+		else
+			ret.append(evaluate(netlist, chunk));
 	}
 	return ret;
 }
@@ -499,44 +726,115 @@ RTLIL::SigSpec VariableState::evaluate(NetlistContext &netlist, VariableBits vbi
 RTLIL::SigSpec VariableState::evaluate(NetlistContext &netlist, VariableChunk vchunk)
 {
 	RTLIL::SigSpec ret;
-	for (uint64_t i = 0; i < vchunk.bitwidth(); i++) {
-		if (visible_assignments.count(vchunk[i])) {
-			ret.append(visible_assignments.at(vchunk[i]));
-		} else {
-			log_assert(vchunk.variable.kind == Variable::Static);
-			ret.append(netlist.wire(*vchunk.variable.get_symbol())[(int)(vchunk.base + i)]);
-		}
+
+	if (!has_overlap(vchunk)) {
+		append_static_value(ret, netlist, vchunk.variable, vchunk.base, vchunk.length);
+		return ret;
 	}
+
+	uint64_t end = vchunk.base + vchunk.length;
+	uint64_t pos = vchunk.base;
+	const auto &segments = visible_assignments.by_variable.at(vchunk.variable);
+	auto segment_it = first_possible_segment(segments, vchunk.base);
+
+	while (pos < end) {
+		if (segment_it == segments.end() || segment_it->base >= end) {
+			append_static_value(ret, netlist, vchunk.variable, pos, end - pos);
+			break;
+		}
+
+		if (pos < segment_it->base) {
+			append_static_value(ret, netlist, vchunk.variable, pos, segment_it->base - pos);
+			pos = segment_it->base;
+			continue;
+		}
+
+		log_assert(pos < segment_it->end());
+		uint64_t width_here = std::min(end - pos, segment_it->end() - pos);
+		ret.append(segment_it->value.extract((int)(pos - segment_it->base), (int)width_here));
+		pos += width_here;
+
+		if (pos == segment_it->end())
+			segment_it++;
+	}
+
+	log_assert(ret.size() == (int)vchunk.length);
 	return ret;
 }
 
-void VariableState::save(Map &save)
+void VariableState::save(SaveState &save)
 {
 	revert.swap(save);
 }
 
-std::pair<VariableBits, RTLIL::SigSpec> VariableState::restore(Map &save)
+std::pair<VariableBits, RTLIL::SigSpec> VariableState::restore(SaveState &save)
 {
 	VariableBits lreverted;
 	RTLIL::SigSpec rreverted;
 
-	for (auto pair : revert)
-		lreverted.append(pair.first);
-	lreverted.sort();
+	// Return branch-final values before rolling visible state back to the
+	// parent branch. The sorted chunk list keeps switch merge output stable.
+	std::vector<VariableChunk> chunks;
+	for (const auto &pair : revert.by_variable) {
+		for (const auto &segment : pair.second)
+			chunks.push_back({pair.first, segment.base, segment.bitwidth()});
+	}
 
-	//rreverted.reserve(lreverted.bitwidth());
-	for (auto bit : lreverted)
-		rreverted.append(visible_assignments.at(bit));
+	std::sort(chunks.begin(), chunks.end(), [](const VariableChunk &lhs, const VariableChunk &rhs) {
+		return std::make_tuple(lhs.variable, lhs.base, lhs.length) <
+			   std::make_tuple(rhs.variable, rhs.base, rhs.length);
+	});
 
-	for (auto pair : revert) {
-		if (pair.second == RTLIL::Sm)
-			visible_assignments.erase(pair.first);
-		else
-			visible_assignments[pair.first] = pair.second;
+	for (auto chunk : chunks) {
+		lreverted.append(VariableBits(chunk));
+		rreverted.append(value_from_store(
+				visible_assignments, chunk.variable, chunk.base, chunk.length, true));
+	}
+
+	for (const auto &pair : revert.by_variable) {
+		for (const auto &segment : pair.second)
+			restore_previous_segment(*this, pair.first, segment);
 	}
 
 	save.swap(revert);
 	return {lreverted, rreverted};
+}
+
+bool VariableState::has_assignment(VariableBit bit) const
+{
+	return has_overlap({bit.variable, bit.offset, 1});
+}
+
+bool VariableState::has_overlap(VariableChunk chunk) const
+{
+	auto segments_it = visible_assignments.by_variable.find(chunk.variable);
+	if (segments_it == visible_assignments.by_variable.end())
+		return false;
+
+	const auto &segments = segments_it->second;
+	auto segment_it = first_possible_segment(segments, chunk.base);
+	return segment_it != segments.end() && segment_it->base < chunk.base + chunk.length;
+}
+
+RTLIL::SigBit VariableState::assignment(VariableBit bit) const
+{
+	RTLIL::SigSpec value = value_from_store(visible_assignments, bit.variable, bit.offset, 1, true);
+	return value[0];
+}
+
+std::vector<VariableChunk> VariableState::assigned_chunks() const
+{
+	std::vector<VariableChunk> chunks;
+	for (const auto &pair : visible_assignments.by_variable) {
+		for (const auto &segment : pair.second)
+			chunks.push_back({pair.first, segment.base, segment.bitwidth()});
+	}
+
+	std::sort(chunks.begin(), chunks.end(), [](const VariableChunk &lhs, const VariableChunk &rhs) {
+		return std::make_tuple(lhs.variable, lhs.base, lhs.length) <
+			   std::make_tuple(rhs.variable, rhs.base, rhs.length);
+	});
+	return chunks;
 }
 
 int EvalContext::find_nest_level(const ast::Scope *scope)
@@ -1706,7 +2004,7 @@ public:
 			if (!dangling.count(driven_bit)) {
 				// No latch inferred
 				cl.append(driven_bit);
-				cr.append(procedure.vstate.visible_assignments.at(driven_bit));
+				cr.append(procedure.vstate.assignment(driven_bit));
 			} else {
 				latch_driven.append(driven_bit);
 			}
@@ -1869,7 +2167,7 @@ public:
 					for (uint64_t i = 0; i < driven_chunk.bitwidth(); i++) {
 						// Is this variable bit assigned to from the async branch?
 						// Depending on this we either use $aldff or $dffe to drive it
-						if (aloads[0].values.visible_assignments.count(driven_chunk[i]))
+						if (aloads[0].values.has_assignment(driven_chunk[i]))
 							aldff_q.append(driven_chunk[i]);
 						else
 							dffe_q.append(driven_chunk[i]);
@@ -2030,6 +2328,21 @@ public:
 			return;
 
 		netlist.add_diag(diag::MultiportUnsupported, sym.location);
+	}
+
+	void assign_module_port_ids(const ast::InstanceBodySymbol &body)
+	{
+		int port_id = 1;
+		for (const ast::Symbol *symbol : body.getPortList()) {
+			if (ast::PortSymbol::isKind(symbol->kind)) {
+				auto &port = symbol->as<ast::PortSymbol>();
+				if (port.internalSymbol && port.internalSymbol->name == port.name) {
+					RTLIL::Wire *wire = netlist.wire(*port.internalSymbol).as_wire();
+					wire->port_id = port_id;
+				}
+			}
+			port_id++;
+		}
 	}
 
 	void inline_port_connection(const ast::PortSymbol &port, RTLIL::SigSpec connection, slang::SourceRange range)
@@ -2563,6 +2876,7 @@ public:
 			// onto RTLIL wires
 			finalize_variable_initialization(netlist);
 			finalize_special_nets(netlist);
+			assign_module_port_ids(body);
 		} else {
 			visitDefault(body);
 		}

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -296,16 +296,40 @@ private:
 
 public:
 	struct VariableState {
-		using Map = Yosys::dict<VariableBit, RTLIL::SigBit>;
+		// Procedural assignments are stored as sorted, non-overlapping
+		// per-variable segments. Branch save/restore uses the same structure
+		// to log the first parent value seen for each touched segment.
+		// Undo segments use Sm bits to mark positions that had no assignment
+		// and should be erased when the saved state is restored.
+		struct Segment {
+			uint64_t base;
+			RTLIL::SigSpec value;
 
-		Map visible_assignments;
-		Map revert;
+			uint64_t end() const { return base + value.size(); }
+			uint64_t bitwidth() const { return value.size(); }
+		};
+
+		struct SegmentStore {
+			Yosys::dict<Variable, std::vector<Segment>> by_variable;
+
+			void clear() { by_variable.clear(); }
+			void swap(SegmentStore &other) { by_variable.swap(other.by_variable); }
+		};
+
+		using SaveState = SegmentStore;
+
+		SegmentStore visible_assignments;
+		SaveState revert;
 
 		void set(VariableBits lhs, RTLIL::SigSpec value);
 		RTLIL::SigSpec evaluate(NetlistContext &netlist, VariableBits vbits);
 		RTLIL::SigSpec evaluate(NetlistContext &netlist, VariableChunk vchunk);
-		void save(Map &save);
-		std::pair<VariableBits, RTLIL::SigSpec> restore(Map &save);
+		void save(SaveState &save);
+		std::pair<VariableBits, RTLIL::SigSpec> restore(SaveState &save);
+		bool has_assignment(VariableBit bit) const;
+		bool has_overlap(VariableChunk chunk) const;
+		RTLIL::SigBit assignment(VariableBit bit) const;
+		std::vector<VariableChunk> assigned_chunks() const;
 	};
 
 	VariableState vstate;

--- a/src/statements.h
+++ b/src/statements.h
@@ -13,7 +13,117 @@
 #include "slang_frontend.h"
 #include "variables.h"
 
+#include <algorithm>
+#include <map>
+
 namespace slang_frontend {
+
+// Collect the ranges touched by any switch branch without flattening them to
+// individual bits. The map keeps variables deterministic, and chunks() merges
+// overlapping per-variable intervals before placeholder creation.
+struct SwitchUpdatedChunks
+{
+	struct Interval
+	{
+		uint64_t base;
+		uint64_t end;
+	};
+
+	std::map<Variable, std::vector<Interval>> by_variable;
+
+	void add(const VariableChunk &chunk)
+	{
+		by_variable[chunk.variable].push_back({chunk.base, chunk.base + chunk.length});
+	}
+
+	void add(const VariableBits &bits)
+	{
+		for (auto chunk : bits.chunks())
+			add(chunk);
+	}
+
+	std::vector<VariableChunk> chunks()
+	{
+		std::vector<VariableChunk> ret;
+
+		for (auto &[variable, intervals] : by_variable) {
+			std::sort(intervals.begin(), intervals.end(), [](const Interval &lhs, const Interval &rhs) {
+				return std::make_tuple(lhs.base, lhs.end) < std::make_tuple(rhs.base, rhs.end);
+			});
+
+			uint64_t base = 0, end = 0;
+			for (auto interval : intervals) {
+				if (base == end) {
+					base = interval.base;
+					end = interval.end;
+					continue;
+				}
+
+				if (interval.base <= end) {
+					end = std::max(end, interval.end);
+					continue;
+				}
+
+				ret.push_back({variable, base, end - base});
+				base = interval.base;
+				end = interval.end;
+			}
+			if (base != end)
+				ret.push_back({variable, base, end - base});
+		}
+
+		return ret;
+	}
+};
+
+// Side table from merged update chunks to their switch-output placeholders.
+// Branch updates can ask for any sub-range of a merged chunk and get the
+// matching placeholder slice in VariableBits order.
+struct SwitchPlaceholderSignals
+{
+	struct Range
+	{
+		VariableChunk chunk;
+		RTLIL::SigSpec signal;
+	};
+
+	std::map<Variable, std::vector<Range>> by_variable;
+
+	void add(const VariableChunk &chunk, const RTLIL::SigSpec &signal)
+	{
+		by_variable[chunk.variable].push_back({chunk, signal});
+	}
+
+	RTLIL::SigSpec signal_for(const VariableChunk &chunk) const
+	{
+		RTLIL::SigSpec ret;
+		auto ranges_it = by_variable.find(chunk.variable);
+		log_assert(ranges_it != by_variable.end());
+		const auto &ranges = ranges_it->second;
+
+		uint64_t done = 0;
+		while (done < chunk.length) {
+			uint64_t bit = chunk.base + done;
+			auto range_it = std::upper_bound(
+					ranges.begin(), ranges.end(), bit,
+					[](uint64_t value, const Range &range) { return value < range.chunk.base; });
+			log_assert(range_it != ranges.begin());
+			range_it--;
+
+			uint64_t range_end = range_it->chunk.base + range_it->chunk.length;
+			log_assert(bit >= range_it->chunk.base);
+			log_assert(bit < range_end);
+			log_assert(range_it->signal.size() == (int)range_it->chunk.length);
+
+			uint64_t range_offset = bit - range_it->chunk.base;
+			uint64_t width = std::min(chunk.length - done, range_it->chunk.length - range_offset);
+			ret.append(range_it->signal.extract((int)range_offset, (int)width));
+			done += width;
+		}
+
+		return ret;
+	}
+};
 
 struct SwitchHelper
 {
@@ -24,7 +134,7 @@ struct SwitchHelper
 	using VariableState = ProceduralContext::VariableState;
 
 	VariableState &vstate;
-	VariableState::Map save_map;
+	VariableState::SaveState save_map;
 	std::vector<std::tuple<Case *, VariableBits, RTLIL::SigSpec>> branch_updates;
 	bool entered = false, finished = false;
 
@@ -89,23 +199,31 @@ struct SwitchHelper
 
 	void finish(NetlistContext &netlist)
 	{
-		VariableBits updated_anybranch;
+		SwitchUpdatedChunks updated_anybranch;
 		for (auto &branch : branch_updates)
-			updated_anybranch.append(std::get<1>(branch));
-		updated_anybranch.sort_and_unify();
+			updated_anybranch.add(std::get<1>(branch));
+		auto updated_chunks = updated_anybranch.chunks();
 
-		// end-of-scope variables
+		// Automatic variables that were created only inside a branch have no
+		// parent-scope value to merge into, so they do not get placeholders.
 		Yosys::pool<Variable> eos_variables;
 
-		auto &va = vstate.visible_assignments;
-		for (auto bit : updated_anybranch)
-			if (bit.variable.kind != Variable::Static && !va.count(bit))
-				eos_variables.insert(bit.variable);
+		for (auto chunk : updated_chunks) {
+			if (chunk.variable.kind == Variable::Static)
+				continue;
+			for (uint64_t i = 0; i < chunk.bitwidth(); i++)
+				if (!vstate.has_assignment(chunk[i]))
+					eos_variables.insert(chunk.variable);
+		}
 
-		for (auto chunk : updated_anybranch.chunks()) {
+		SwitchPlaceholderSignals placeholder_signals;
+
+		// Create one placeholder per merged chunk and publish it as the
+		// visible value after the switch.
+		for (auto chunk : updated_chunks) {
 			if (chunk.variable.kind != Variable::Static && eos_variables.count(chunk.variable)) {
 				for (uint64_t i = 0; i < chunk.bitwidth(); i++)
-					log_assert(!va.count(chunk[i]));
+					log_assert(!vstate.has_assignment(chunk[i]));
 
 				continue;
 			}
@@ -121,9 +239,12 @@ struct SwitchHelper
 			RTLIL::SigSpec w_default = vstate.evaluate(netlist, chunk);
 			RTLIL::SigSpec w = netlist.add_placeholder_signal(chunk.bitwidth(), name_suggestion);
 			parent->aux_actions.push_back(RTLIL::SigSig(w, w_default));
+			placeholder_signals.add(chunk, w);
 			vstate.set(chunk, w);
 		}
 
+		// Re-target each branch's original updates onto slices of the merged
+		// placeholders created above.
 		for (auto &branch : branch_updates) {
 			Case *rule;
 			VariableBits target;
@@ -137,12 +258,7 @@ struct SwitchHelper
 					continue;
 				}
 
-				// get the wire (or some part of it) which we created up above
-				RTLIL::SigSpec target_w;
-				for (uint64_t i = 0; i < chunk.bitwidth(); i++) {
-					log_assert(va.count(chunk[i]));
-					target_w.append(va.at(chunk[i]));
-				}
+				RTLIL::SigSpec target_w = placeholder_signals.signal_for(chunk);
 
 				rule->aux_actions.push_back(
 						RTLIL::SigSig(target_w, source.extract(done, (int)chunk.bitwidth())));

--- a/src/variables.cc
+++ b/src/variables.cc
@@ -162,7 +162,7 @@ bool Variable::operator<(const Variable &other) const
 			else
 				return order_symbols_within_scope(symbol, other.symbol);
 		}
-		return false;
+		return depth < other.depth;
 	} else if (kind == EscapeFlag) {
 		return id < other.id;
 	} else if (kind == Dummy) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(ALL_TESTS
     unit/expression_attrs.ys
     unit/latch.ys
     unit/selftests.tcl
+    unit/switchhelper_rank1_order.tcl
     various/assign_mixing.ys
     various/assignment_pattern_lhs.ys
     various/bb_detect.ys

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ set(ALL_TESTS
     unit/function_call.ys
     unit/expression_attrs.ys
     unit/latch.ys
+    unit/expr_bitwise_z_simplification.tcl
     unit/selftests.tcl
     unit/switchhelper_rank1_order.tcl
     various/assign_mixing.ys

--- a/tests/unit/expr_bitwise_z_simplification.tcl
+++ b/tests/unit/expr_bitwise_z_simplification.tcl
@@ -1,0 +1,50 @@
+yosys -import
+
+set sv_source {
+module expr_bitwise_z_simplification(
+	input logic dynamic_bit
+);
+	wire [1:0] and_equal = {1'bz, dynamic_bit} & {1'bz, dynamic_bit};
+	wire [1:0] or_equal = {1'bz, dynamic_bit} | {1'bz, dynamic_bit};
+	wire [1:0] and_one_left = {1'bz, dynamic_bit} & 2'b11;
+	wire [1:0] and_one_right = 2'b11 & {1'bz, dynamic_bit};
+	wire [1:0] or_zero_left = {1'bz, dynamic_bit} | 2'b00;
+	wire [1:0] or_zero_right = 2'b00 | {1'bz, dynamic_bit};
+endmodule
+}
+
+set sv_file [file join /tmp "yosys_slang_expr_bitwise_z_simplification_[pid].sv"]
+set sv_fd [open $sv_file w]
+puts -nonewline $sv_fd $sv_source
+close $sv_fd
+
+read_slang $sv_file
+file delete -force $sv_file
+
+set dump_file [file join /tmp "yosys_slang_expr_bitwise_z_simplification_[pid].il"]
+write_rtlil $dump_file
+
+set fd [open $dump_file r]
+set rtlil [read $fd]
+close $fd
+file delete -force $dump_file
+
+proc reject_preserved_z_result {rtlil signal} {
+	set preserved_z [format {connect \A { 1'z \dynamic_bit }
+    connect \Y \%s} $signal]
+
+	if {[string first $preserved_z $rtlil] >= 0} {
+		error "bitwise simplification preserved 1'bz in $signal instead of producing unknown"
+	}
+}
+
+foreach signal {
+	and_equal
+	or_equal
+	and_one_left
+	and_one_right
+	or_zero_left
+	or_zero_right
+} {
+	reject_preserved_z_result $rtlil $signal
+}

--- a/tests/unit/expr_boolean_cone.sv
+++ b/tests/unit/expr_boolean_cone.sv
@@ -1,0 +1,62 @@
+module expr_boolean_cone_1bit(
+	input logic a,
+	input logic b,
+	input logic c,
+	input logic d
+);
+	wire and_chain = ((a & b) & c) & d;
+	wire or_chain = ((a | b) | c) | d;
+	wire dup_chain = (a & b) | (a & b);
+	wire mixed_not = (~(a & b)) | c;
+
+	always_comb begin
+		if (a === 1'b0 || b === 1'b0 || c === 1'b0 || d === 1'b0)
+			assert(and_chain === 1'b0);
+		if (a === 1'b1 && b === 1'b1 && c === 1'b1 && d === 1'b1)
+			assert(and_chain === 1'b1);
+		if (a === 1'bx && b === 1'b1 && c === 1'b1 && d === 1'b1)
+			assert(and_chain === 1'bx);
+
+		if (a === 1'b1 || b === 1'b1 || c === 1'b1 || d === 1'b1)
+			assert(or_chain === 1'b1);
+		if (a === 1'b0 && b === 1'b0 && c === 1'b0 && d === 1'b0)
+			assert(or_chain === 1'b0);
+		if (a === 1'bx && b === 1'b0 && c === 1'b0 && d === 1'b0)
+			assert(or_chain === 1'bx);
+
+		if (a === 1'b0 || b === 1'b0)
+			assert(dup_chain === 1'b0);
+		if (a === 1'b1 && b === 1'b1)
+			assert(dup_chain === 1'b1);
+		if (a === 1'bx && b === 1'b1)
+			assert(dup_chain === 1'bx);
+
+		if (a === 1'b1 && b === 1'b1 && c === 1'b0)
+			assert(mixed_not === 1'b0);
+		if (a === 1'b0 && c === 1'b0)
+			assert(mixed_not === 1'b1);
+		if (a === 1'bx && b === 1'b1 && c === 1'b0)
+			assert(mixed_not === 1'bx);
+	end
+endmodule
+
+module expr_boolean_cone_multibit(
+	input logic [3:0] a,
+	input logic [3:0] b,
+	input logic [3:0] c
+);
+	wire [3:0] actual_and = a & b & c;
+	wire [3:0] actual_or = a | b | c;
+	logic [3:0] expected_and;
+	logic [3:0] expected_or;
+
+	always_comb begin
+		for (int i = 0; i < 4; i++) begin
+			expected_and[i] = a[i] & b[i] & c[i];
+			expected_or[i] = a[i] | b[i] | c[i];
+		end
+
+		assert(actual_and === expected_and);
+		assert(actual_or === expected_or);
+	end
+endmodule

--- a/tests/unit/switchhelper_rank1.sv
+++ b/tests/unit/switchhelper_rank1.sv
@@ -1,0 +1,160 @@
+module switchhelper_rank1_alignment(
+	input logic sel,
+	input logic [7:0] seed
+);
+	logic [7:0] actual;
+	logic [7:0] expected;
+
+	always_comb begin
+		actual = seed;
+		expected = seed;
+
+		if (sel) begin
+			{actual[0], actual[7], actual[3:2]} = {seed[6], seed[1], seed[5:4]};
+			expected[0] = seed[6];
+			expected[7] = seed[1];
+			expected[3:2] = seed[5:4];
+		end else begin
+			{actual[6:5], actual[1]} = {seed[2:1], seed[7]};
+			expected[6:5] = seed[2:1];
+			expected[1] = seed[7];
+		end
+
+		if (sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module switchhelper_rank1_partial_overlap(
+	input logic sel,
+	input logic [7:0] base,
+	input logic [5:0] hi,
+	input logic [5:0] lo
+);
+	logic [7:0] actual;
+	logic [7:0] expected;
+
+	always_comb begin
+		actual = base;
+		expected = base;
+
+		if (sel) begin
+			actual[7:2] = hi;
+			expected[7:2] = hi;
+		end else begin
+			actual[5:0] = lo;
+			expected[5:0] = lo;
+		end
+
+		if (sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module switchhelper_rank1_automatic_eos(
+	input logic sel,
+	input logic [3:0] a,
+	input logic [3:0] b
+);
+	logic [3:0] actual;
+	logic [3:0] expected;
+
+	always_comb begin
+		actual = 4'h0;
+
+		if (sel) begin
+			automatic logic [3:0] tmp;
+			tmp = {a[0], a[3:1]};
+			actual = tmp;
+		end else begin
+			automatic logic [3:0] tmp;
+			tmp = {b[2:0], b[3]};
+			actual = tmp;
+		end
+
+		expected = sel ? {a[0], a[3:1]} : {b[2:0], b[3]};
+
+		if (sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module switchhelper_rank1_order(
+	input logic [1:0] sel,
+	input logic [7:0] a,
+	input logic [7:0] b,
+	input logic [7:0] c,
+	output logic [7:0] y
+);
+	always_comb begin
+		y = a;
+		case (sel)
+			2'b00: begin
+				y[7:2] = b[5:0];
+			end
+			2'b01: begin
+				{y[1], y[6:5], y[3]} = {c[7], c[2:1], c[0]};
+			end
+			2'b10: begin
+				y[5:0] = c[5:0];
+			end
+			default: begin
+				y[4:2] = b[7:5];
+			end
+		endcase
+	end
+endmodule
+
+module switchhelper_rank1_reentrant_automatic_local(
+	input logic sel,
+	input logic [5:0] seed
+);
+	logic [5:0] actual;
+	logic [5:0] expected;
+
+	function automatic logic [5:0] recurse(input logic [1:0] n, input logic [5:0] value);
+		automatic logic [5:0] tmp;
+		automatic logic [5:0] child;
+		begin
+			tmp = value ^ {4'b0000, n};
+			if (n != 0) begin
+				if (sel) begin
+					child = recurse(n - 2'd1, tmp + 6'd3);
+					tmp = tmp ^ {child[2:0], child[5:3]};
+				end else begin
+					child = recurse(n - 2'd1, tmp + 6'd5);
+					tmp = tmp + {child[0], child[5:1]};
+				end
+			end
+			recurse = tmp;
+		end
+	endfunction
+
+	always_comb begin
+		logic [5:0] f2_tmp;
+		logic [5:0] f2_child;
+		logic [5:0] f1_input;
+		logic [5:0] f1_tmp;
+		logic [5:0] f1_child;
+
+		actual = recurse(2'd2, seed);
+
+		f2_tmp = seed ^ 6'd2;
+		if (sel) begin
+			f1_input = f2_tmp + 6'd3;
+			f1_tmp = f1_input ^ 6'd1;
+			f1_child = (f1_tmp + 6'd3) ^ 6'd0;
+			f2_child = f1_tmp ^ {f1_child[2:0], f1_child[5:3]};
+			expected = f2_tmp ^ {f2_child[2:0], f2_child[5:3]};
+		end else begin
+			f1_input = f2_tmp + 6'd5;
+			f1_tmp = f1_input ^ 6'd1;
+			f1_child = (f1_tmp + 6'd5) ^ 6'd0;
+			f2_child = f1_tmp + {f1_child[0], f1_child[5:1]};
+			expected = f2_tmp + {f2_child[0], f2_child[5:1]};
+		end
+
+		if (sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule

--- a/tests/unit/switchhelper_rank1_order.tcl
+++ b/tests/unit/switchhelper_rank1_order.tcl
@@ -1,0 +1,40 @@
+yosys -import
+
+set sv_file [file join [pwd] switchhelper_rank1.sv]
+set first_dump [file join /tmp "yosys_slang_switchhelper_rank1_order_[pid]_a.il"]
+set second_dump [file join /tmp "yosys_slang_switchhelper_rank1_order_[pid]_b.il"]
+
+proc dump_order_test {sv_file dump_file} {
+	design -reset
+	# This test covers frontend-generated process ordering, not Yosys's
+	# version-specific proc lowering order.
+	read_slang --no-proc $sv_file
+	hierarchy -top switchhelper_rank1_order
+	write_rtlil $dump_file
+}
+
+proc normalized_rtlil {dump_file} {
+	set fd [open $dump_file r]
+	set text [read $fd]
+	close $fd
+
+	# A single Yosys process intentionally keeps allocating fresh internal
+	# auto names across design resets. Normalize those IDs while preserving the
+	# generated port, statement, cell, wire, and connection ordering.
+	regsub -all {autoidx [0-9]+} $text {autoidx <N>} text
+	regsub -all {\$procmux\$[0-9]+} $text {$procmux$<N>} text
+	regsub -all {\$[0-9]+} $text {$<N>} text
+	return $text
+}
+
+dump_order_test $sv_file $first_dump
+dump_order_test $sv_file $second_dump
+
+set first_text [normalized_rtlil $first_dump]
+set second_text [normalized_rtlil $second_dump]
+
+file delete -force $first_dump $second_dump
+
+if {$first_text ne $second_text} {
+	error "switchhelper_rank1_order RTLIL output changed between identical reads"
+}

--- a/tests/unit/variablestate_rank23.sv
+++ b/tests/unit/variablestate_rank23.sv
@@ -1,0 +1,139 @@
+module variablestate_rank2_repeated_write(
+	input logic sel,
+	input logic [7:0] base,
+	input logic [7:0] a,
+	input logic [7:0] b
+);
+	logic [7:0] actual;
+	logic [7:0] expected;
+
+	always_comb begin
+		actual = base;
+		expected = base;
+
+		if (sel) begin
+			actual[5:1] = a[4:0];
+			actual[5:1] = b[4:0];
+			expected[5:1] = b[4:0];
+		end else begin
+			actual[7:3] = a[7:3];
+			expected[7:3] = a[7:3];
+		end
+
+		if (sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module variablestate_rank2_nested_branch(
+	input logic outer,
+	input logic inner,
+	input logic [9:0] base,
+	input logic [5:0] a,
+	input logic [5:0] b,
+	input logic [5:0] c
+);
+	logic [9:0] actual;
+	logic [9:0] expected;
+
+	always_comb begin
+		actual = base;
+		expected = base;
+
+		if (outer) begin
+			actual[7:2] = a;
+			expected[7:2] = a;
+
+			if (inner) begin
+				actual[5:0] = b;
+				expected[5:0] = b;
+			end else begin
+				actual[9:4] = c;
+				expected[9:4] = c;
+			end
+		end else begin
+			actual[8:3] = c;
+			expected[8:3] = c;
+		end
+
+		if (outer !== 1'bx && inner !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module variablestate_rank2_masked_overlap(
+	input logic [1:0] sel,
+	input logic [7:0] base,
+	input logic [3:0] data
+);
+	logic [7:0] actual;
+	logic [7:0] expected;
+
+	always_comb begin
+		actual = base;
+		expected = base;
+
+		actual[sel +: 4] = data;
+
+		if (^sel !== 1'bx) begin
+			for (int i = 0; i < 4; i++)
+				expected[sel + i] = data[i];
+			assert(actual === expected);
+		end
+	end
+endmodule
+
+module variablestate_rank23_sparse_fields(
+	input logic [3:0] valid,
+	output logic [31:0] packed_entries
+);
+	typedef struct packed {
+		logic [6:0] payload;
+		logic valid;
+	} entry_t;
+
+	entry_t [3:0] entries;
+
+	always_comb begin
+		for (int i = 0; i < 4; i++)
+			entries[i].valid = valid[i];
+
+		packed_entries = entries;
+
+		assert(packed_entries[0] === valid[0]);
+		assert(packed_entries[8] === valid[1]);
+		assert(packed_entries[16] === valid[2]);
+		assert(packed_entries[24] === valid[3]);
+	end
+endmodule
+
+module variablestate_rank3_mixed_static_visible(
+	input logic [7:0] data,
+	output logic [15:0] value,
+	output logic [11:0] slice
+);
+	always_comb begin
+		value[11:4] = data;
+		slice = value[13:2];
+
+		assert(slice[0] === value[2]);
+		assert(slice[1] === value[3]);
+		assert(slice[9:2] === data);
+		assert(slice[10] === value[12]);
+		assert(slice[11] === value[13]);
+	end
+endmodule
+
+module variablestate_rank3_static_miss(
+	input logic [15:0] a,
+	input logic [15:0] b,
+	output logic [15:0] actual
+);
+	assign actual[15:8] = b[15:8];
+
+	always_comb begin
+		actual[7:0] = a[7:0];
+
+		assert(actual === {b[15:8], a[7:0]});
+	end
+endmodule


### PR DESCRIPTION

Fold local $and/$or identity, annihilator, and duplicate-operand cases before emitting cells. Preserve four-state behavior by converting z bits in identity results to x.

Add focused boolean cone and z-identity regression coverage.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/povik/yosys-slang/pull/333).
* #339
* #338
* #337
* #336
* #335
* #334
* __->__ #333
* #332