### PR TITLE
Bound dynamic LHS element updates

### DIFF
--- a/src/addressing.cc
+++ b/src/addressing.cc
@@ -301,9 +301,9 @@ RTLIL::SigSpec AddressingResolver::shift_down_bitwise(RTLIL::SigSpec val, int ou
 
 RTLIL::SigSpec AddressingResolver::shift_down(RTLIL::SigSpec val, int output_len)
 {
-	if (raw_signal.is_fully_def()) {
+	if (raw_signal.is_fully_def())
 		return extract(val, output_len);
-	} else if (stride == 1) {
+	else if (stride == 1) {
 		return shift_down_bitwise(val, output_len);
 	} else {
 		RTLIL::SigSpec ret(RTLIL::Sm, output_len);

--- a/src/addressing.cc
+++ b/src/addressing.cc
@@ -16,7 +16,25 @@
 #include "slang_frontend.h"
 #include "variables.h"
 
+#include <limits>
+
 namespace slang_frontend {
+
+static int64_t min_signed_value_for_width(int width)
+{
+	log_assert(width > 0);
+	if (width >= 63)
+		return std::numeric_limits<int64_t>::min();
+	return -(1ll << (width - 1));
+}
+
+static int64_t max_signed_value_for_width(int width)
+{
+	log_assert(width > 0);
+	if (width >= 63)
+		return std::numeric_limits<int64_t>::max();
+	return (1ll << (width - 1)) - 1;
+}
 
 void AddressingResolver::interpret_index(RTLIL::SigSpec signal, int width_down, int width_up)
 {
@@ -225,6 +243,33 @@ RTLIL::SigSpec AddressingResolver::demux(RTLIL::SigSpec val, int output_len)
 			val, -std::max(0, base_offset), std::max(0, output_len / stride - base_offset));
 
 	return demuxed.extract(std::max(0, -stride * base_offset), output_len);
+}
+
+RTLIL::SigSpec AddressingResolver::demux_window(
+		RTLIL::SigSpec val, uint64_t first_element, uint64_t element_count)
+{
+	log_assert(val.size() == stride);
+	log_assert(element_count > 0);
+	log_assert(element_count < (1u << 23));
+	log_assert(element_count <=
+			(uint64_t)std::numeric_limits<int>::max() / (uint64_t)std::max(1, stride));
+
+	__int128 requested_first = (__int128)first_element - base_offset;
+	__int128 requested_last = requested_first + element_count - 1;
+	__int128 valid_first = std::max(requested_first, (__int128)min_signed_value_for_width(raw_signal.size()));
+	__int128 valid_last = std::min(requested_last, (__int128)max_signed_value_for_width(raw_signal.size()));
+	if (valid_first > valid_last)
+		return RTLIL::SigSpec(RTLIL::S0, (int)(element_count * stride));
+
+	uint64_t prefix_zeros = (uint64_t)(valid_first - requested_first);
+	uint64_t valid_count = (uint64_t)(valid_last - valid_first + 1);
+	uint64_t suffix_zeros = element_count - prefix_zeros - valid_count;
+
+	RTLIL::SigSpec ret;
+	ret.append(RTLIL::SigSpec(RTLIL::S0, (int)(prefix_zeros * stride)));
+	ret.append(netlist.DemuxWindow(val, raw_signal, (int64_t)valid_first, valid_count, true));
+	ret.append(RTLIL::SigSpec(RTLIL::S0, (int)(suffix_zeros * stride)));
+	return ret;
 }
 
 RTLIL::SigSpec AddressingResolver::raw_mux(RTLIL::SigSpec val, int from, int to, int stride)

--- a/src/builder.cc
+++ b/src/builder.cc
@@ -4,7 +4,14 @@
 // Copyright Martin Povišer <povik@cutebit.org>
 // Distributed under the terms of the ISC license, see LICENSE
 //
+#include <algorithm>
 #include <limits>
+
+// Fix for Yosys declaring ceil_log2 as both inline and non-inline
+// but not defining the non-inline one; be sure to include utils.h
+// with the inline definition to prevent linkage errors on some
+// platforms
+#include "kernel/utils.h"
 
 #include "slang_frontend.h"
 #include "variables.h"
@@ -70,6 +77,8 @@ SigSpec RTLILBuilder::Demux(SigSpec a, SigSpec s)
 {
 	log_assert(s.size() < 24);
 	SigSpec zeropad(RTLIL::S0, a.size());
+	if (a.is_fully_zero())
+		return SigSpec(RTLIL::S0, a.size() << s.size());
 	if (s.is_fully_const()) {
 		int idx_const = s.as_const().as_int();
 		return {zeropad.repeat((1 << s.size()) - 1 - idx_const), a, zeropad.repeat(idx_const)};
@@ -77,6 +86,58 @@ SigSpec RTLILBuilder::Demux(SigSpec a, SigSpec s)
 	auto [id, y] = add_y_wire(a.size() << s.size());
 	bless_cell(canvas->addDemux(id, a, s, y));
 	return y;
+}
+
+SigSpec RTLILBuilder::DemuxWindow(
+		SigSpec a, SigSpec s, int64_t first_branch, uint64_t branch_count, bool s_signed)
+{
+	log_assert(branch_count > 0);
+	log_assert(branch_count < (1u << 23));
+	log_assert((uint64_t)std::max(1, a.size()) <=
+			(uint64_t)std::numeric_limits<int>::max() / branch_count);
+
+	int output_width = a.size() * (int)branch_count;
+	if (a.is_fully_zero())
+		return SigSpec(RTLIL::S0, output_width);
+
+	if (s.is_fully_const()) {
+		int64_t idx_const = s.as_const().as_int(s_signed);
+		int64_t branch = idx_const - first_branch;
+		if (branch < 0 || branch >= (int64_t)branch_count)
+			return SigSpec(RTLIL::S0, output_width);
+
+		SigSpec ret(RTLIL::S0, output_width);
+		ret.replace((int)branch * a.size(), a);
+		return ret;
+	}
+
+	if (branch_count == 1) {
+		SigSpec expected(RTLIL::Const(first_branch, s.size()));
+		SigSpec guard = Eq(s, expected);
+		SigSpec bit_guards(guard[0], a.size());
+		if (a.is_fully_ones())
+			return bit_guards;
+		return Bwmux(SigSpec(RTLIL::S0, a.size()), a, bit_guards);
+	}
+
+	int demux_width = 1 << ceil_log2((int)branch_count);
+	int select_width = ceil_log2(demux_width);
+	int relative_width = std::max(s.size() + 1, select_width + 1);
+
+	SigSpec first_const(RTLIL::Const(first_branch, s.size()));
+	SigSpec relative = Biop(ID($sub), s, first_const, s_signed, s_signed, relative_width);
+	SigSpec in_range = Eq(relative.extract(select_width, relative_width - select_width),
+			SigSpec(RTLIL::S0, relative_width - select_width));
+	SigSpec guards = Demux(in_range, relative.extract(0, select_width)).extract(0, branch_count);
+
+	SigSpec bit_guards;
+	for (uint64_t i = 0; i < branch_count; i++)
+		bit_guards.append(SigSpec(guards[(int)i], a.size()));
+
+	if (a.is_fully_ones())
+		return bit_guards;
+
+	return Bwmux(SigSpec(RTLIL::S0, output_width), a.repeat((int)branch_count), bit_guards);
 }
 
 SigSpec RTLILBuilder::Le(SigSpec a, SigSpec b, bool is_signed)
@@ -175,6 +236,8 @@ SigSpec RTLILBuilder::Mux(SigSpec a, SigSpec b, SigSpec s)
 		return a;
 	if (s[0] == RTLIL::S1)
 		return b;
+	if (a == b)
+		return a;
 	auto [id, y] = add_y_wire(a.size());
 	bless_cell(canvas->addMux(id, a, b, s, y));
 	return y;
@@ -184,6 +247,8 @@ SigSpec RTLILBuilder::Bwmux(SigSpec a, SigSpec b, SigSpec s)
 {
 	log_assert(a.size() == b.size());
 	log_assert(a.size() == s.size());
+	if (a == b)
+		return a;
 	if (s.is_fully_const()) {
 		SigSpec result(RTLIL::Sx, a.size());
 		for (int i = 0; i < a.size(); i++) {

--- a/src/builder.cc
+++ b/src/builder.cc
@@ -323,6 +323,27 @@ int convert(RTLIL::SigBit bit)
 }
 }; // namespace ThreeValued
 
+static SigSpec bitwise_identity_result(SigSpec sig)
+{
+	std::vector<int> z_offsets;
+	int offset = 0;
+
+	for (const RTLIL::SigChunk &chunk : sig.chunks()) {
+		if (!chunk.is_wire()) {
+			for (int i = 0; i < chunk.width; i++) {
+				if (chunk.data[i] == RTLIL::Sz)
+					z_offsets.push_back(offset + i);
+			}
+		}
+		offset += chunk.width;
+	}
+
+	for (int z_offset : z_offsets)
+		sig[z_offset] = RTLIL::Sx;
+
+	return sig;
+}
+
 SigSpec RTLILBuilder::Biop(
 		IdString op, SigSpec a, SigSpec b, bool a_signed, bool b_signed, int y_width)
 {
@@ -396,6 +417,27 @@ SigSpec RTLILBuilder::Biop(
 			SigSpec ret = {RTLIL::S1};
 			ret.extend_u0(y_width);
 			return ret;
+		}
+	}
+
+	if (op.in(ID($and), ID($or)) && a.size() == y_width && b.size() == y_width) {
+		if (a == b)
+			return bitwise_identity_result(a);
+
+		if (op == ID($and)) {
+			if (a.is_fully_zero() || b.is_fully_zero())
+				return SigSpec(RTLIL::S0, y_width);
+			if (a.is_fully_ones())
+				return bitwise_identity_result(b);
+			if (b.is_fully_ones())
+				return bitwise_identity_result(a);
+		} else {
+			if (a.is_fully_ones() || b.is_fully_ones())
+				return SigSpec(RTLIL::S1, y_width);
+			if (a.is_fully_zero())
+				return bitwise_identity_result(b);
+			if (b.is_fully_zero())
+				return bitwise_identity_result(a);
 		}
 	}
 

--- a/src/builder.cc
+++ b/src/builder.cc
@@ -441,6 +441,19 @@ SigSpec RTLILBuilder::Biop(
 		}
 	}
 
+	bool use_binary_cell_cache = op.in(ID($and), ID($or)) && y_width == 1 &&
+								 a.size() == 1 && b.size() == 1 &&
+								 !a_signed && !b_signed && staged_attributes.empty();
+	BinaryCellKey binary_cell_key;
+	if (use_binary_cell_cache) {
+		if (b < a)
+			std::swap(a, b);
+		binary_cell_key = {op, a, b, a_signed, b_signed, y_width};
+		auto cached = binary_cell_cache.find(binary_cell_key);
+		if (cached != binary_cell_cache.end())
+			return cached->second;
+	}
+
 	int msb_zeroes = 0;
 	if (op == ID($mul) && !a_signed && !b_signed) {
 		int as = a.size(), bs = b.size();
@@ -462,7 +475,10 @@ SigSpec RTLILBuilder::Biop(
 	cell->setParam(RTLIL::ID::Y_WIDTH, y_width - msb_zeroes);
 	cell->setPort(RTLIL::ID::Y, y);
 	bless_cell(cell);
-	return {SigSpec(RTLIL::S0, msb_zeroes), y};
+	SigSpec ret = {SigSpec(RTLIL::S0, msb_zeroes), y};
+	if (use_binary_cell_cache)
+		binary_cell_cache[binary_cell_key] = ret;
+	return ret;
 }
 
 SigSpec RTLILBuilder::Unop(IdString op, SigSpec a, bool a_signed, int y_width)
@@ -483,6 +499,16 @@ SigSpec RTLILBuilder::Unop(IdString op, SigSpec a, bool a_signed, int y_width)
 #undef OP
 	}
 
+	bool use_unary_cell_cache = op == ID($not) && y_width == 1 &&
+								a.size() == 1 && !a_signed && staged_attributes.empty();
+	UnaryCellKey unary_cell_key;
+	if (use_unary_cell_cache) {
+		unary_cell_key = {op, a, a_signed, y_width};
+		auto cached = unary_cell_cache.find(unary_cell_key);
+		if (cached != unary_cell_cache.end())
+			return cached->second;
+	}
+
 	auto [id, y] = add_y_wire(y_width);
 	Cell *cell = canvas->addCell(id, op);
 	cell->setPort(RTLIL::ID::A, a);
@@ -491,6 +517,8 @@ SigSpec RTLILBuilder::Unop(IdString op, SigSpec a, bool a_signed, int y_width)
 	cell->setParam(RTLIL::ID::Y_WIDTH, y_width);
 	cell->setPort(RTLIL::ID::Y, y);
 	bless_cell(cell);
+	if (use_unary_cell_cache)
+		unary_cell_cache[unary_cell_key] = y;
 	return y;
 }
 

--- a/src/builder.cc
+++ b/src/builder.cc
@@ -15,6 +15,8 @@ using RTLIL::Cell;
 using RTLIL::IdString;
 using RTLIL::SigSpec;
 
+static constexpr int wide_unary_cache_max_width = 64;
+
 // A compat util to be removed once we drop 0.59 support
 #if YOSYS_MAJOR == 0 && YOSYS_MINOR < 59
 static IdString id(std::string_view sv)
@@ -499,13 +501,21 @@ SigSpec RTLILBuilder::Unop(IdString op, SigSpec a, bool a_signed, int y_width)
 #undef OP
 	}
 
-	bool use_unary_cell_cache = op == ID($not) && y_width == 1 &&
-								a.size() == 1 && !a_signed && staged_attributes.empty();
+	bool cacheable_not = op == ID($not) && y_width > 0 &&
+			y_width <= wide_unary_cache_max_width && a.size() == y_width &&
+			!a_signed && staged_attributes.empty();
+	bool use_legacy_unary_cell_cache = cacheable_not && y_width == 1;
+	bool use_wide_unary_cell_cache = cacheable_not && y_width > 1;
+
 	UnaryCellKey unary_cell_key;
-	if (use_unary_cell_cache) {
+	if (use_legacy_unary_cell_cache) {
 		unary_cell_key = {op, a, a_signed, y_width};
 		auto cached = unary_cell_cache.find(unary_cell_key);
 		if (cached != unary_cell_cache.end())
+			return cached->second;
+	} else if (use_wide_unary_cell_cache) {
+		auto cached = wide_unary_cell_cache.find(a);
+		if (cached != wide_unary_cell_cache.end())
 			return cached->second;
 	}
 
@@ -517,8 +527,10 @@ SigSpec RTLILBuilder::Unop(IdString op, SigSpec a, bool a_signed, int y_width)
 	cell->setParam(RTLIL::ID::Y_WIDTH, y_width);
 	cell->setPort(RTLIL::ID::Y, y);
 	bless_cell(cell);
-	if (use_unary_cell_cache)
+	if (use_legacy_unary_cell_cache)
 		unary_cell_cache[unary_cell_key] = y;
+	else if (use_wide_unary_cell_cache)
+		wide_unary_cell_cache[a] = y;
 	return y;
 }
 

--- a/src/lvalue.cc
+++ b/src/lvalue.cc
@@ -71,7 +71,7 @@ std::optional<LValue> LValue::analyze(
 				expr, rse.value().type->isBitstreamType() && rse.value().type->hasFixedRange());
 		AddressingResolver resolver(context, rse);
 
-		std::optional<LValue> inner = analyze(context, rse.value());
+		std::optional<LValue> inner = analyze(context, rse.value(), silent);
 		if (!inner)
 			return std::nullopt;
 
@@ -84,7 +84,7 @@ std::optional<LValue> LValue::analyze(
 		ast_invariant(
 				expr, ese.value().type->isBitstreamType() && ese.value().type->hasFixedRange());
 
-		if (context.netlist.is_inferred_memory(ese.value()) &&
+		if (context.netlist.is_inferred_memory(ese.value()) && context.procedural &&
 				context.procedural->timing.kind != ProcessTiming::Initial) {
 			RTLIL::SigSpec address = context(ese.selector());
 			auto variable =
@@ -92,7 +92,7 @@ std::optional<LValue> LValue::analyze(
 			return LValue::memoryWrite(variable, address, ese.type->getBitstreamWidth());
 		}
 
-		std::optional<LValue> inner = analyze(context, ese.value());
+		std::optional<LValue> inner = analyze(context, ese.value(), silent);
 		if (!inner)
 			return std::nullopt;
 
@@ -115,7 +115,7 @@ std::optional<LValue> LValue::analyze(
 	case ast::ExpressionKind::MemberAccess: {
 		const auto &acc = expr.as<ast::MemberAccessExpression>();
 
-		std::optional<LValue> inner = analyze(context, acc.value());
+		std::optional<LValue> inner = analyze(context, acc.value(), silent);
 		if (!inner)
 			return std::nullopt;
 

--- a/src/procedural.cc
+++ b/src/procedural.cc
@@ -135,18 +135,12 @@ void ProceduralContext::copy_case_tree_into(RTLIL::CaseRule &rule)
 VariableBits ProceduralContext::all_driven()
 {
 	VariableBits all_driven;
-	for (auto pair : vstate.visible_assignments) {
-		all_driven.append(pair.first);
+	for (auto chunk : vstate.assigned_chunks()) {
+		if (chunk.variable.kind == Variable::Static)
+			all_driven.append(VariableBits(chunk));
 	}
 
-	all_driven.sort_and_unify();
-
-	VariableBits all_driven_filtered;
-	for (auto chunk : all_driven.chunks())
-		if (chunk.variable.kind == Variable::Static)
-			all_driven_filtered.append(VariableBits(chunk));
-
-	return all_driven_filtered;
+	return all_driven;
 }
 
 RTLIL::SigBit ProceduralContext::case_enable()

--- a/src/procedural.cc
+++ b/src/procedural.cc
@@ -5,6 +5,8 @@
 // Distributed under the terms of the ISC license, see LICENSE
 //
 
+#include <algorithm>
+
 #include "slang/ast/Statement.h"
 #include "slang/ast/expressions/AssignmentExpressions.h"
 #include "slang/ast/expressions/ConversionExpression.h"
@@ -27,6 +29,10 @@
 #include "variables.h"
 
 namespace slang_frontend {
+
+// Bound dynamic element-select updates by target bits. A single lane can be
+// wider than this cap, so block sizing still allows one element per update.
+static constexpr uint64_t max_dynamic_lhs_block_bits = 1024;
 
 EnterAutomaticScopeGuard::EnterAutomaticScopeGuard(EvalContext &context, const ast::Scope *scope)
 	: context(context), scope(scope)
@@ -187,6 +193,45 @@ void crop_undef_mask(const RTLIL::SigSpec &mask, VariableBits &target)
 	}
 }
 
+// Keep dynamic element-like writes bounded without materializing a full-width
+// repeated RHS and mask before update_variable_state() can crop them.
+static bool try_assign_dynamic_element_with_masking(const ast::AssignmentExpression &assign,
+		ProceduralContext &context, AddressingResolver &resolver, LValue &inner,
+		uint64_t element_width, const RTLIL::SigSpec &rvalue, const RTLIL::SigSpec &mask,
+		bool blocking)
+{
+	if (resolver.is_static() || resolver.stride != (int)element_width || !inner.is_static())
+		return false;
+	if (context.timing.kind == ProcessTiming::Initial)
+		return false;
+
+	VariableBits inner_vbits = inner.evaluate_vbits();
+	if (inner_vbits.bitwidth() % element_width != 0)
+		return false;
+
+	uint64_t element_count = inner_vbits.bitwidth() / element_width;
+	if (mask.is_fully_zero())
+		return true;
+
+	uint64_t max_block_elements =
+			std::max<uint64_t>(1, max_dynamic_lhs_block_bits / element_width);
+	uint64_t elements_per_block = std::min(element_count, max_block_elements);
+
+	for (uint64_t first = 0; first < element_count; first += elements_per_block) {
+		uint64_t block_elements = std::min(elements_per_block, element_count - first);
+		RTLIL::SigSpec block_mask = resolver.demux_window(mask, first, block_elements);
+		if (block_mask.is_fully_zero())
+			continue;
+
+		VariableBits target =
+			inner_vbits.extract(first * element_width, block_elements * element_width);
+		context.update_variable_state(assign.sourceRange.start(), std::move(target),
+				rvalue.repeat(block_elements), std::move(block_mask), blocking);
+	}
+
+	return true;
+}
+
 void ProceduralContext::update_variable_state(slang::SourceLocation loc, VariableBits lvalue,
 		RTLIL::SigSpec unmasked_rvalue, RTLIL::SigSpec mask, bool blocking)
 {
@@ -284,18 +329,20 @@ void ProceduralContext::update_variable_state(slang::SourceLocation loc, Variabl
 		// shortcut path to support initialization of automatic variables
 		// (evaluating the background value is unavailable on the first
 		// assignment)
-		vstate.set(lvalue, unmasked_rvalue);
+		vstate.set(std::move(lvalue), std::move(unmasked_rvalue));
 	} else {
 		RTLIL::SigSpec rvalue_background = vstate.evaluate(netlist, lvalue);
 		RTLIL::SigSpec rvalue = netlist.Bwmux(rvalue_background, unmasked_rvalue, mask);
-		vstate.set(lvalue, rvalue);
+		vstate.set(std::move(lvalue), std::move(rvalue));
 	}
 }
 
 void ProceduralContext::do_simple_assign(
 		slang::SourceLocation loc, VariableBits lvalue, RTLIL::SigSpec rvalue, bool blocking)
 {
-	update_variable_state(loc, lvalue, rvalue, RTLIL::SigSpec(RTLIL::S1, rvalue.size()), blocking);
+	int width = rvalue.size();
+	update_variable_state(loc, std::move(lvalue), std::move(rvalue),
+			RTLIL::SigSpec(RTLIL::S1, width), blocking);
 }
 
 RTLIL::SigSpec ProceduralContext::substitute_rvalue(VariableBits bits)
@@ -359,6 +406,11 @@ void assign_to_lvalue_with_masking(const ast::AssignmentExpression &assign,
 		log_assert(base == 0);
 	} else if (auto range_sel = std::get_if<LValue::RangeSelect>(&lvalue.descriptor)) {
 		if (range_sel->resolver->stride == lvalue.bitsize) {
+			if (try_assign_dynamic_element_with_masking(
+						assign, context, *range_sel->resolver, *range_sel->inner, lvalue.bitsize,
+						rvalue, mask, blocking))
+				return;
+
 			// Effectively an element select
 			assign_to_lvalue_with_masking(assign, context, *range_sel->inner,
 					rvalue.repeat(range_sel->resolver->range.width()),

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -1547,14 +1547,16 @@ RTLIL::SigSpec EvalContext::operator()(ast::Expression const &expr)
 				require(valsym, valsym.getInitializer());
 				auto exprconst = valsym.getInitializer()->eval(this->const_);
 				require(valsym, exprconst.isInteger());
-				return convert_svint(exprconst.integer());
+				ret = convert_svint(exprconst.integer());
+				goto done;
 			}
 
 			if (ast::ModportPortSymbol::isKind(symbol.kind) &&
 					!netlist.scopes_remap.count(symbol.getParentScope())) {
 				auto &modport_port = symbol.as<ast::ModportPortSymbol>();
 				ast_invariant(symbol, modport_port.getConnectionExpr() != nullptr);
-				return (*this)(*modport_port.getConnectionExpr());
+				ret = (*this)(*modport_port.getConnectionExpr());
+				goto done;
 			}
 
 			ast_invariant(symbol, ast::ValueSymbol::isKind(symbol.kind));
@@ -1646,13 +1648,14 @@ RTLIL::SigSpec EvalContext::operator()(ast::Expression const &expr)
 				if (!right.is_fully_const()) {
 					netlist.add_diag(diag::NonconstWildcardEq, expr.sourceRange);
 					ret = netlist.add_placeholder_signal(expr.type->getBitstreamWidth());
-					return ret;
+					goto done;
 				}
-				return netlist.Unop(
+				ret = netlist.Unop(
 					invert ? ID($logic_not) : ID($reduce_bool),
 					netlist.EqWildcard(left, right),
 					false, expr.type->getBitstreamWidth()
 				);
+				goto done;
 			default:
 				break;
 			}
@@ -3577,7 +3580,6 @@ const RTLIL::SigSpec& NetlistContext::wire(const ast::Symbol &symbol)
 RTLIL::SigSpec NetlistContext::convert_static(VariableBits bits)
 {
 	RTLIL::SigSpec ret;
-
 	for (auto vchunk : bits.chunks()) {
 		switch (vchunk.variable.kind) {
 		case Variable::Static: {

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -5,6 +5,7 @@
 // Distributed under the terms of the ISC license, see LICENSE
 //
 // clang-format off
+#include <algorithm>
 #include <vector>
 
 #include "slang/ast/ASTVisitor.h"
@@ -461,37 +462,263 @@ const ast::InstanceBodySymbol &get_instance_body(SynthesisSettings &settings, co
 }
 
 using VariableState = ProceduralContext::VariableState;
+using StateSegment = VariableState::Segment;
+using StateSegmentStore = VariableState::SegmentStore;
+
+// Segment helpers maintain sorted, non-overlapping per-variable ranges.
+// append_segment() also coalesces adjacent ranges after callers split or
+// overwrite existing segments.
+static void append_segment(std::vector<StateSegment> &segments, StateSegment segment)
+{
+	if (segment.bitwidth() == 0)
+		return;
+
+	if (!segments.empty() && segments.back().end() == segment.base) {
+		segments.back().value.append(segment.value);
+		return;
+	}
+
+	log_assert(segments.empty() || segments.back().end() < segment.base);
+	segments.push_back(segment);
+}
+
+static std::vector<StateSegment>::const_iterator first_possible_segment(
+		const std::vector<StateSegment> &segments, uint64_t base)
+{
+	return std::lower_bound(segments.begin(), segments.end(), base,
+			[](const StateSegment &segment, uint64_t value) { return segment.end() <= value; });
+}
+
+static void set_segment(std::vector<StateSegment> &segments, uint64_t base, RTLIL::SigSpec value)
+{
+	if (value.empty())
+		return;
+
+	uint64_t end = base + value.size();
+
+	if (segments.empty() || segments.back().end() <= base) {
+		append_segment(segments, {base, value});
+		return;
+	}
+
+	std::vector<StateSegment> updated;
+	updated.reserve(segments.size() + 1);
+	bool inserted = false;
+
+	for (const auto &segment : segments) {
+		if (segment.end() <= base) {
+			append_segment(updated, segment);
+			continue;
+		}
+
+		if (segment.base >= end) {
+			if (!inserted) {
+				append_segment(updated, {base, value});
+				inserted = true;
+			}
+			append_segment(updated, segment);
+			continue;
+		}
+
+		if (segment.base < base) {
+			append_segment(updated, {
+					segment.base,
+					segment.value.extract(0, (int)(base - segment.base))
+			});
+		}
+
+		if (!inserted) {
+			append_segment(updated, {base, value});
+			inserted = true;
+		}
+
+		if (segment.end() > end) {
+			append_segment(updated, {
+					end,
+					segment.value.extract((int)(end - segment.base), (int)(segment.end() - end))
+			});
+		}
+	}
+
+	if (!inserted)
+		append_segment(updated, {base, value});
+
+	segments.swap(updated);
+}
+
+static void erase_segment(std::vector<StateSegment> &segments, uint64_t base, uint64_t width)
+{
+	if (width == 0 || segments.empty())
+		return;
+
+	uint64_t end = base + width;
+	if (segments.back().end() <= base)
+		return;
+
+	std::vector<StateSegment> updated;
+	updated.reserve(segments.size());
+
+	for (const auto &segment : segments) {
+		if (segment.end() <= base || segment.base >= end) {
+			append_segment(updated, segment);
+			continue;
+		}
+
+		if (segment.base < base) {
+			append_segment(updated, {
+					segment.base,
+					segment.value.extract(0, (int)(base - segment.base))
+			});
+		}
+
+		if (segment.end() > end) {
+			append_segment(updated, {
+					end,
+					segment.value.extract((int)(end - segment.base), (int)(segment.end() - end))
+			});
+		}
+	}
+
+	segments.swap(updated);
+}
+
+static RTLIL::SigSpec value_from_store(const StateSegmentStore &store,
+		Variable variable, uint64_t base, uint64_t width, bool require_present)
+{
+	RTLIL::SigSpec ret;
+	uint64_t end = base + width;
+	auto segments_it = store.by_variable.find(variable);
+	if (segments_it == store.by_variable.end()) {
+		log_assert(!require_present);
+		return RTLIL::SigSpec(RTLIL::Sm, (int)width);
+	}
+
+	const auto &segments = segments_it->second;
+	auto segment_it = first_possible_segment(segments, base);
+	uint64_t pos = base;
+
+	while (pos < end) {
+		if (segment_it == segments.end() || segment_it->base >= end) {
+			log_assert(!require_present);
+			ret.append(RTLIL::SigSpec(RTLIL::Sm, (int)(end - pos)));
+			break;
+		}
+
+		if (pos < segment_it->base) {
+			log_assert(!require_present);
+			ret.append(RTLIL::SigSpec(RTLIL::Sm, (int)(segment_it->base - pos)));
+			pos = segment_it->base;
+			continue;
+		}
+
+		log_assert(pos < segment_it->end());
+		uint64_t width_here = std::min(end - pos, segment_it->end() - pos);
+		ret.append(segment_it->value.extract((int)(pos - segment_it->base), (int)width_here));
+		pos += width_here;
+
+		if (pos == segment_it->end())
+			segment_it++;
+	}
+
+	log_assert(ret.size() == (int)width);
+	return ret;
+}
+
+static void append_static_value(
+		RTLIL::SigSpec &ret, NetlistContext &netlist, Variable variable,
+		uint64_t base, uint64_t width)
+{
+	if (width == 0)
+		return;
+
+	if (variable.kind == Variable::Dummy) {
+		ret.append(RTLIL::SigSpec(RTLIL::Sx, (int)width));
+		return;
+	}
+
+	log_assert(variable.kind == Variable::Static);
+	ret.append(netlist.wire(*variable.get_symbol()).extract((int)base, (int)width));
+}
+
+static void record_undo(VariableState &state, const VariableChunk &chunk)
+{
+	auto &undo_segments = state.revert.by_variable[chunk.variable];
+	std::vector<std::pair<uint64_t, uint64_t>> gaps;
+
+	// Save only spans not already in the undo log. Branch restore is
+	// first-touch based, so later writes must not replace the parent value.
+	uint64_t end = chunk.base + chunk.length;
+	uint64_t pos = chunk.base;
+	auto segment_it = first_possible_segment(undo_segments, chunk.base);
+
+	while (pos < end) {
+		if (segment_it == undo_segments.end() || segment_it->base >= end) {
+			gaps.push_back({pos, end - pos});
+			break;
+		}
+
+		if (pos < segment_it->base) {
+			uint64_t gap_end = std::min(end, segment_it->base);
+			gaps.push_back({pos, gap_end - pos});
+			pos = gap_end;
+			continue;
+		}
+
+		log_assert(pos < segment_it->end());
+		pos = std::min(end, segment_it->end());
+		segment_it++;
+	}
+
+	for (auto [gap_base, gap_width] : gaps) {
+		set_segment(undo_segments, gap_base,
+				value_from_store(state.visible_assignments, chunk.variable, gap_base, gap_width, false));
+	}
+}
+
+static void restore_previous_segment(VariableState &state, Variable variable, StateSegment previous)
+{
+	int pos = 0;
+	auto &segments = state.visible_assignments.by_variable[variable];
+
+	// Undo values use Sm for bits that were absent in the parent state. Split
+	// those runs so restore erases them instead of writing sentinel bits back.
+	while (pos < previous.value.size()) {
+		bool absent = previous.value[pos] == RTLIL::Sm;
+		int start = pos;
+		while (pos < previous.value.size() && (previous.value[pos] == RTLIL::Sm) == absent)
+			pos++;
+
+		uint64_t base = previous.base + start;
+		int width = pos - start;
+		if (absent)
+			erase_segment(segments, base, width);
+		else
+			set_segment(segments, base, previous.value.extract(start, width));
+	}
+
+	if (segments.empty())
+		state.visible_assignments.by_variable.erase(variable);
+}
 
 void VariableState::set(VariableBits lhs, RTLIL::SigSpec value)
 {
 	log_assert(lhs.bitwidth() == (uint64_t)value.size());
 
-	for (uint64_t i = 0; i < lhs.bitwidth(); i++) {
-		VariableBit bit = lhs[i];
-
-		if (!revert.count(bit)) {
-			if (visible_assignments.count(bit))
-				revert[bit] = visible_assignments.at(bit);
-			else
-				revert[bit] = RTLIL::Sm;
-		}
-
-		visible_assignments[bit] = value[i];
+	for (auto [base, size, chunk] : lhs.chunk_spans()) {
+		record_undo(*this, chunk);
+		set_segment(visible_assignments.by_variable[chunk.variable], chunk.base,
+				value.extract((int)base, (int)size));
 	}
 }
 
 RTLIL::SigSpec VariableState::evaluate(NetlistContext &netlist, VariableBits vbits)
 {
 	RTLIL::SigSpec ret;
-	for (auto vbit : vbits) {
-		if (vbit.variable.kind == Variable::Dummy) {
-			ret.append(RTLIL::Sx);
-		} else if (visible_assignments.count(vbit)) {
-			ret.append(visible_assignments.at(vbit));
-		} else {
-			log_assert(vbit.variable.kind == Variable::Static);
-			ret.append(netlist.wire(*vbit.variable.get_symbol())[(int)vbit.offset]);
-		}
+	for (auto chunk : vbits.chunks()) {
+		if (chunk.variable.kind == Variable::Dummy)
+			ret.append(RTLIL::SigSpec(RTLIL::Sx, (int)chunk.length));
+		else
+			ret.append(evaluate(netlist, chunk));
 	}
 	return ret;
 }
@@ -499,44 +726,115 @@ RTLIL::SigSpec VariableState::evaluate(NetlistContext &netlist, VariableBits vbi
 RTLIL::SigSpec VariableState::evaluate(NetlistContext &netlist, VariableChunk vchunk)
 {
 	RTLIL::SigSpec ret;
-	for (uint64_t i = 0; i < vchunk.bitwidth(); i++) {
-		if (visible_assignments.count(vchunk[i])) {
-			ret.append(visible_assignments.at(vchunk[i]));
-		} else {
-			log_assert(vchunk.variable.kind == Variable::Static);
-			ret.append(netlist.wire(*vchunk.variable.get_symbol())[(int)(vchunk.base + i)]);
-		}
+
+	if (!has_overlap(vchunk)) {
+		append_static_value(ret, netlist, vchunk.variable, vchunk.base, vchunk.length);
+		return ret;
 	}
+
+	uint64_t end = vchunk.base + vchunk.length;
+	uint64_t pos = vchunk.base;
+	const auto &segments = visible_assignments.by_variable.at(vchunk.variable);
+	auto segment_it = first_possible_segment(segments, vchunk.base);
+
+	while (pos < end) {
+		if (segment_it == segments.end() || segment_it->base >= end) {
+			append_static_value(ret, netlist, vchunk.variable, pos, end - pos);
+			break;
+		}
+
+		if (pos < segment_it->base) {
+			append_static_value(ret, netlist, vchunk.variable, pos, segment_it->base - pos);
+			pos = segment_it->base;
+			continue;
+		}
+
+		log_assert(pos < segment_it->end());
+		uint64_t width_here = std::min(end - pos, segment_it->end() - pos);
+		ret.append(segment_it->value.extract((int)(pos - segment_it->base), (int)width_here));
+		pos += width_here;
+
+		if (pos == segment_it->end())
+			segment_it++;
+	}
+
+	log_assert(ret.size() == (int)vchunk.length);
 	return ret;
 }
 
-void VariableState::save(Map &save)
+void VariableState::save(SaveState &save)
 {
 	revert.swap(save);
 }
 
-std::pair<VariableBits, RTLIL::SigSpec> VariableState::restore(Map &save)
+std::pair<VariableBits, RTLIL::SigSpec> VariableState::restore(SaveState &save)
 {
 	VariableBits lreverted;
 	RTLIL::SigSpec rreverted;
 
-	for (auto pair : revert)
-		lreverted.append(pair.first);
-	lreverted.sort();
+	// Return branch-final values before rolling visible state back to the
+	// parent branch. The sorted chunk list keeps switch merge output stable.
+	std::vector<VariableChunk> chunks;
+	for (const auto &pair : revert.by_variable) {
+		for (const auto &segment : pair.second)
+			chunks.push_back({pair.first, segment.base, segment.bitwidth()});
+	}
 
-	//rreverted.reserve(lreverted.bitwidth());
-	for (auto bit : lreverted)
-		rreverted.append(visible_assignments.at(bit));
+	std::sort(chunks.begin(), chunks.end(), [](const VariableChunk &lhs, const VariableChunk &rhs) {
+		return std::make_tuple(lhs.variable, lhs.base, lhs.length) <
+			   std::make_tuple(rhs.variable, rhs.base, rhs.length);
+	});
 
-	for (auto pair : revert) {
-		if (pair.second == RTLIL::Sm)
-			visible_assignments.erase(pair.first);
-		else
-			visible_assignments[pair.first] = pair.second;
+	for (auto chunk : chunks) {
+		lreverted.append(VariableBits(chunk));
+		rreverted.append(value_from_store(
+				visible_assignments, chunk.variable, chunk.base, chunk.length, true));
+	}
+
+	for (const auto &pair : revert.by_variable) {
+		for (const auto &segment : pair.second)
+			restore_previous_segment(*this, pair.first, segment);
 	}
 
 	save.swap(revert);
 	return {lreverted, rreverted};
+}
+
+bool VariableState::has_assignment(VariableBit bit) const
+{
+	return has_overlap({bit.variable, bit.offset, 1});
+}
+
+bool VariableState::has_overlap(VariableChunk chunk) const
+{
+	auto segments_it = visible_assignments.by_variable.find(chunk.variable);
+	if (segments_it == visible_assignments.by_variable.end())
+		return false;
+
+	const auto &segments = segments_it->second;
+	auto segment_it = first_possible_segment(segments, chunk.base);
+	return segment_it != segments.end() && segment_it->base < chunk.base + chunk.length;
+}
+
+RTLIL::SigBit VariableState::assignment(VariableBit bit) const
+{
+	RTLIL::SigSpec value = value_from_store(visible_assignments, bit.variable, bit.offset, 1, true);
+	return value[0];
+}
+
+std::vector<VariableChunk> VariableState::assigned_chunks() const
+{
+	std::vector<VariableChunk> chunks;
+	for (const auto &pair : visible_assignments.by_variable) {
+		for (const auto &segment : pair.second)
+			chunks.push_back({pair.first, segment.base, segment.bitwidth()});
+	}
+
+	std::sort(chunks.begin(), chunks.end(), [](const VariableChunk &lhs, const VariableChunk &rhs) {
+		return std::make_tuple(lhs.variable, lhs.base, lhs.length) <
+			   std::make_tuple(rhs.variable, rhs.base, rhs.length);
+	});
+	return chunks;
 }
 
 int EvalContext::find_nest_level(const ast::Scope *scope)
@@ -1706,7 +2004,7 @@ public:
 			if (!dangling.count(driven_bit)) {
 				// No latch inferred
 				cl.append(driven_bit);
-				cr.append(procedure.vstate.visible_assignments.at(driven_bit));
+				cr.append(procedure.vstate.assignment(driven_bit));
 			} else {
 				latch_driven.append(driven_bit);
 			}
@@ -1869,7 +2167,7 @@ public:
 					for (uint64_t i = 0; i < driven_chunk.bitwidth(); i++) {
 						// Is this variable bit assigned to from the async branch?
 						// Depending on this we either use $aldff or $dffe to drive it
-						if (aloads[0].values.visible_assignments.count(driven_chunk[i]))
+						if (aloads[0].values.has_assignment(driven_chunk[i]))
 							aldff_q.append(driven_chunk[i]);
 						else
 							dffe_q.append(driven_chunk[i]);
@@ -2030,6 +2328,21 @@ public:
 			return;
 
 		netlist.add_diag(diag::MultiportUnsupported, sym.location);
+	}
+
+	void assign_module_port_ids(const ast::InstanceBodySymbol &body)
+	{
+		int port_id = 1;
+		for (const ast::Symbol *symbol : body.getPortList()) {
+			if (ast::PortSymbol::isKind(symbol->kind)) {
+				auto &port = symbol->as<ast::PortSymbol>();
+				if (port.internalSymbol && port.internalSymbol->name == port.name) {
+					RTLIL::Wire *wire = netlist.wire(*port.internalSymbol).as_wire();
+					wire->port_id = port_id;
+				}
+			}
+			port_id++;
+		}
 	}
 
 	void inline_port_connection(const ast::PortSymbol &port, RTLIL::SigSpec connection, slang::SourceRange range)
@@ -2563,6 +2876,7 @@ public:
 			// onto RTLIL wires
 			finalize_variable_initialization(netlist);
 			finalize_special_nets(netlist);
+			assign_module_port_ids(body);
 		} else {
 			visitDefault(body);
 		}

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -101,6 +101,9 @@ namespace parsing = slang::parsing;
 ast::Compilation *global_compilation;
 const slang::SourceManager *global_sourcemgr;
 
+static constexpr size_t static_rvalue_cache_max_entries = 65536;
+static constexpr uint64_t static_rvalue_cache_max_cost = 4 * 1024 * 1024;
+
 slang::SourceRange source_location(const ast::Symbol &obj)			{ return slang::SourceRange(obj.location, obj.location); }
 slang::SourceRange source_location(const ast::Expression &expr)		{ return expr.sourceRange; }
 slang::SourceRange source_location(const ast::Statement &stmt)		{ return stmt.sourceRange; }
@@ -1451,6 +1454,113 @@ RTLIL::SigSpec EvalContext::sva(ast::Expression const &expr)
 	return ret;
 }
 
+static bool evaluates_to_defined_integer(
+		const ast::Expression &expr, ast::EvalContext &context)
+{
+	auto value = expr.eval(context);
+	return value && value.isInteger() && !value.integer().hasUnknown();
+}
+
+static bool has_static_rvalue_shape(EvalContext &context, const ast::Expression &expr)
+{
+	if (!expr.type || !expr.type->isFixedSize() || expr.type->isVoid())
+		return false;
+
+	// Keep this prefilter cheaper and stricter than LValue::analyze(), which
+	// may evaluate selectors and construct addressing state before rejecting.
+	switch (expr.kind) {
+	case ast::ExpressionKind::HierarchicalValue:
+	case ast::ExpressionKind::NamedValue: {
+		const ast::Symbol &symbol = expr.as<ast::ValueExpressionBase>().symbol;
+		return ast::ValueSymbol::isKind(symbol.kind) &&
+				!ast::ParameterSymbol::isKind(symbol.kind) &&
+				!context.netlist.is_inferred_memory(symbol);
+	}
+	case ast::ExpressionKind::MemberAccess:
+		return has_static_rvalue_shape(
+				context, expr.as<ast::MemberAccessExpression>().value());
+	case ast::ExpressionKind::ElementSelect: {
+		const auto &select = expr.as<ast::ElementSelectExpression>();
+		if (!select.value().type->isBitstreamType() || !select.value().type->hasFixedRange() ||
+				context.netlist.is_inferred_memory(select.value()))
+			return false;
+		return evaluates_to_defined_integer(select.selector(), context.const_) &&
+				has_static_rvalue_shape(context, select.value());
+	}
+	case ast::ExpressionKind::RangeSelect: {
+		const auto &select = expr.as<ast::RangeSelectExpression>();
+		if (!select.value().type->isBitstreamType() || !select.value().type->hasFixedRange())
+			return false;
+
+		if (!evaluates_to_defined_integer(select.left(), context.const_) ||
+				!evaluates_to_defined_integer(select.right(), context.const_))
+			return false;
+
+		return has_static_rvalue_shape(context, select.value());
+	}
+	case ast::ExpressionKind::Conversion: {
+		const auto &conversion = expr.as<ast::ConversionExpression>();
+		if (conversion.operand().kind == ast::ExpressionKind::Streaming)
+			return false;
+		const ast::Type &from = conversion.operand().type->getCanonicalType();
+		const ast::Type &to = conversion.type->getCanonicalType();
+		return to.isBitstreamType() && from.isBitstreamType() &&
+				from.getBitstreamWidth() == to.getBitstreamWidth() &&
+				has_static_rvalue_shape(context, conversion.operand());
+	}
+	case ast::ExpressionKind::Concatenation: {
+		const auto &concat = expr.as<ast::ConcatenationExpression>();
+		for (auto operand : concat.operands()) {
+			if (!has_static_rvalue_shape(context, *operand))
+				return false;
+		}
+		return true;
+	}
+	default:
+		return false;
+	}
+}
+
+static uint64_t variable_bits_cache_cost(const VariableBits &bits)
+{
+	uint64_t cost = bits.bitwidth();
+	for (auto chunk : bits.chunks()) {
+		(void)chunk;
+		cost += 16;
+	}
+	return cost;
+}
+
+std::optional<RTLIL::SigSpec> EvalContext::static_rvalue_signal(ast::Expression const &expr)
+{
+	if (procedural || in_sva_expression || !has_static_rvalue_shape(*this, expr))
+		return std::nullopt;
+
+	auto cached = netlist.static_rvalue_cache.find(&expr);
+	if (cached != netlist.static_rvalue_cache.end())
+		return cached->second;
+
+	auto lvalue = LValue::analyze(*this, expr, true);
+	if (!lvalue || !lvalue->is_static())
+		return std::nullopt;
+
+	VariableBits bits = lvalue->evaluate_vbits();
+	if (bits.bitwidth() != expr.type->getBitstreamWidth() || bits.has_dummy_bits())
+		return std::nullopt;
+
+	// Store only fully validated static RHS expressions; any rejected shape
+	// falls back to the normal expression lowering path.
+	uint64_t cost = variable_bits_cache_cost(bits);
+	RTLIL::SigSpec signal = netlist.convert_static(bits);
+	if (netlist.static_rvalue_cache.size() < static_rvalue_cache_max_entries &&
+			netlist.static_rvalue_cache_cost + cost <= static_rvalue_cache_max_cost) {
+		netlist.static_rvalue_cache[&expr] = signal;
+		netlist.static_rvalue_cache_cost += cost;
+	}
+
+	return signal;
+}
+
 RTLIL::SigSpec EvalContext::operator()(ast::Expression const &expr)
 {
 	RTLIL::Module *mod = netlist.canvas;
@@ -1487,6 +1597,11 @@ RTLIL::SigSpec EvalContext::operator()(ast::Expression const &expr)
 				goto error;
 			}
 		}
+	}
+
+	if (auto static_signal = static_rvalue_signal(expr)) {
+		ret = *static_signal;
+		goto done;
 	}
 
 	switch (expr.kind) {

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -18,6 +18,7 @@
 
 template<> struct Yosys::hashlib::hash_ops<const slang::ast::Symbol*> : Yosys::hashlib::hash_ptr_ops {};
 template<> struct Yosys::hashlib::hash_ops<const slang::ast::Scope*> : Yosys::hashlib::hash_ptr_ops {};
+template<> struct Yosys::hashlib::hash_ops<const slang::ast::Expression*> : Yosys::hashlib::hash_ptr_ops {};
 template<> struct Yosys::hashlib::hash_ops<void*> : Yosys::hashlib::hash_ptr_ops {};
 
 namespace slang {
@@ -140,6 +141,7 @@ struct EvalContext {
 
 	RTLIL::SigSpec apply_conversion(const ast::ConversionExpression &conv, RTLIL::SigSpec op);
 	RTLIL::SigSpec apply_nested_conversion(const ast::Expression &expr, RTLIL::SigSpec val);
+	std::optional<RTLIL::SigSpec> static_rvalue_signal(ast::Expression const &expr);
 	VariableBits streaming_lhs(ast::StreamingConcatenationExpression const &expr);
 	RTLIL::SigSpec streaming(ast::StreamingConcatenationExpression const &expr);
 
@@ -609,6 +611,10 @@ struct NetlistContext : RTLILBuilder, public DiagnosticIssuer {
 	const RTLIL::SigSpec& add_wire(const ast::ValueSymbol &sym);
 	const RTLIL::SigSpec& wire(const ast::Symbol &sym);
 	RTLIL::SigSpec convert_static(VariableBits bits);
+
+	// Cache successful static RHS expression analyses after all shape checks.
+	Yosys::dict<const ast::Expression*, RTLIL::SigSpec> static_rvalue_cache;
+	uint64_t static_rvalue_cache_cost = 0;
 
 	struct Memory {
 		int num_wr_ports = 0;

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -296,16 +296,40 @@ private:
 
 public:
 	struct VariableState {
-		using Map = Yosys::dict<VariableBit, RTLIL::SigBit>;
+		// Procedural assignments are stored as sorted, non-overlapping
+		// per-variable segments. Branch save/restore uses the same structure
+		// to log the first parent value seen for each touched segment.
+		// Undo segments use Sm bits to mark positions that had no assignment
+		// and should be erased when the saved state is restored.
+		struct Segment {
+			uint64_t base;
+			RTLIL::SigSpec value;
 
-		Map visible_assignments;
-		Map revert;
+			uint64_t end() const { return base + value.size(); }
+			uint64_t bitwidth() const { return value.size(); }
+		};
+
+		struct SegmentStore {
+			Yosys::dict<Variable, std::vector<Segment>> by_variable;
+
+			void clear() { by_variable.clear(); }
+			void swap(SegmentStore &other) { by_variable.swap(other.by_variable); }
+		};
+
+		using SaveState = SegmentStore;
+
+		SegmentStore visible_assignments;
+		SaveState revert;
 
 		void set(VariableBits lhs, RTLIL::SigSpec value);
 		RTLIL::SigSpec evaluate(NetlistContext &netlist, VariableBits vbits);
 		RTLIL::SigSpec evaluate(NetlistContext &netlist, VariableChunk vchunk);
-		void save(Map &save);
-		std::pair<VariableBits, RTLIL::SigSpec> restore(Map &save);
+		void save(SaveState &save);
+		std::pair<VariableBits, RTLIL::SigSpec> restore(SaveState &save);
+		bool has_assignment(VariableBit bit) const;
+		bool has_overlap(VariableChunk chunk) const;
+		RTLIL::SigBit assignment(VariableBit bit) const;
+		std::vector<VariableChunk> assigned_chunks() const;
 	};
 
 	VariableState vstate;

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -419,10 +419,12 @@ struct RTLILBuilder {
 	// cell; many expression leaves never need an `src` string.
 	slang::SourceRange staged_source_range;
 	bool staged_source_range_valid = false;
-	// Source-only one-bit expression CSE. These caches are used only when no
-	// staged user attributes would be lost by reusing an existing cell result.
+	// Source-only expression CSE is used only when no staged user attributes
+	// would be lost. The wider unary cache is separate so it cannot evict the
+	// original high-hit one-bit working set.
 	Yosys::dict<BinaryCellKey, SigSpec> binary_cell_cache;
 	Yosys::dict<UnaryCellKey, SigSpec> unary_cell_cache;
+	Yosys::dict<SigSpec, SigSpec> wide_unary_cell_cache;
 
 	unsigned next_id = 0;
 	std::string new_id(std::string base = std::string());

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -362,12 +362,65 @@ private:
 struct RTLILBuilder {
 	using SigSpec = RTLIL::SigSpec;
 
+	struct BinaryCellKey {
+		RTLIL::IdString op;
+		SigSpec a;
+		SigSpec b;
+		bool a_signed = false;
+		bool b_signed = false;
+		int y_width = 0;
+
+		bool operator==(const BinaryCellKey &other) const
+		{
+			return op == other.op && a == other.a && b == other.b &&
+				   a_signed == other.a_signed && b_signed == other.b_signed &&
+				   y_width == other.y_width;
+		}
+
+		[[nodiscard]] Yosys::Hasher hash_into(Yosys::Hasher h) const
+		{
+			h.eat(op);
+			h.eat(a);
+			h.eat(b);
+			h.eat(a_signed);
+			h.eat(b_signed);
+			h.eat(y_width);
+			return h;
+		}
+	};
+
+	struct UnaryCellKey {
+		RTLIL::IdString op;
+		SigSpec a;
+		bool a_signed = false;
+		int y_width = 0;
+
+		bool operator==(const UnaryCellKey &other) const
+		{
+			return op == other.op && a == other.a &&
+				   a_signed == other.a_signed && y_width == other.y_width;
+		}
+
+		[[nodiscard]] Yosys::Hasher hash_into(Yosys::Hasher h) const
+		{
+			h.eat(op);
+			h.eat(a);
+			h.eat(a_signed);
+			h.eat(y_width);
+			return h;
+		}
+	};
+
 	RTLIL::Module *canvas;
 	Yosys::dict<RTLIL::IdString, RTLIL::Const> staged_attributes;
 	// Source ranges are kept unformatted until bless_cell() actually emits a
 	// cell; many expression leaves never need an `src` string.
 	slang::SourceRange staged_source_range;
 	bool staged_source_range_valid = false;
+	// Source-only one-bit expression CSE. These caches are used only when no
+	// staged user attributes would be lost by reusing an existing cell result.
+	Yosys::dict<BinaryCellKey, SigSpec> binary_cell_cache;
+	Yosys::dict<UnaryCellKey, SigSpec> unary_cell_cache;
 
 	unsigned next_id = 0;
 	std::string new_id(std::string base = std::string());
@@ -616,6 +669,7 @@ struct NetlistContext : RTLILBuilder, public DiagnosticIssuer {
 	void add_continuous_driver(VariableBits lhs, RTLIL::SigSpec rhs);
 
 	const std::optional<RTLIL::Const> convert_const(const slang::ConstantValue &constval, slang::SourceLocation loc);
+
 };
 
 // slang_frontend.cc

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -432,6 +432,10 @@ struct RTLILBuilder {
 	SigSpec ReduceBool(SigSpec a);
 
 	SigSpec Demux(SigSpec a, SigSpec s);
+	// Return only the contiguous branch window
+	// [first_branch, first_branch + branch_count) from a demux.
+	SigSpec DemuxWindow(SigSpec a, SigSpec s, int64_t first_branch, uint64_t branch_count,
+			bool s_signed=false);
 	SigSpec Le(SigSpec a, SigSpec b, bool is_signed);
 	SigSpec Ge(SigSpec a, SigSpec b, bool is_signed);
 	SigSpec Lt(SigSpec a, SigSpec b, bool is_signed);
@@ -726,6 +730,11 @@ public:
 
 	RTLIL::SigSpec shift_up(RTLIL::SigSpec val, bool oor_undef, int output_len);
 	RTLIL::SigSpec demux(RTLIL::SigSpec val, int output_len);
+	// Like demux(), but returns only the mask bits for zero-based elements
+	// [first_element, first_element + element_count). The input val is one
+	// element wide, and the result is element_count elements wide.
+	RTLIL::SigSpec demux_window(
+			RTLIL::SigSpec val, uint64_t first_element, uint64_t element_count);
 	RTLIL::SigSpec mux(RTLIL::SigSpec val, int output_len);
 	RTLIL::SigSpec shift_down(RTLIL::SigSpec val, int output_len);
 	template <typename Bundle> Bundle extract(Bundle val, uint64_t width);

--- a/src/statements.h
+++ b/src/statements.h
@@ -13,7 +13,117 @@
 #include "slang_frontend.h"
 #include "variables.h"
 
+#include <algorithm>
+#include <map>
+
 namespace slang_frontend {
+
+// Collect the ranges touched by any switch branch without flattening them to
+// individual bits. The map keeps variables deterministic, and chunks() merges
+// overlapping per-variable intervals before placeholder creation.
+struct SwitchUpdatedChunks
+{
+	struct Interval
+	{
+		uint64_t base;
+		uint64_t end;
+	};
+
+	std::map<Variable, std::vector<Interval>> by_variable;
+
+	void add(const VariableChunk &chunk)
+	{
+		by_variable[chunk.variable].push_back({chunk.base, chunk.base + chunk.length});
+	}
+
+	void add(const VariableBits &bits)
+	{
+		for (auto chunk : bits.chunks())
+			add(chunk);
+	}
+
+	std::vector<VariableChunk> chunks()
+	{
+		std::vector<VariableChunk> ret;
+
+		for (auto &[variable, intervals] : by_variable) {
+			std::sort(intervals.begin(), intervals.end(), [](const Interval &lhs, const Interval &rhs) {
+				return std::make_tuple(lhs.base, lhs.end) < std::make_tuple(rhs.base, rhs.end);
+			});
+
+			uint64_t base = 0, end = 0;
+			for (auto interval : intervals) {
+				if (base == end) {
+					base = interval.base;
+					end = interval.end;
+					continue;
+				}
+
+				if (interval.base <= end) {
+					end = std::max(end, interval.end);
+					continue;
+				}
+
+				ret.push_back({variable, base, end - base});
+				base = interval.base;
+				end = interval.end;
+			}
+			if (base != end)
+				ret.push_back({variable, base, end - base});
+		}
+
+		return ret;
+	}
+};
+
+// Side table from merged update chunks to their switch-output placeholders.
+// Branch updates can ask for any sub-range of a merged chunk and get the
+// matching placeholder slice in VariableBits order.
+struct SwitchPlaceholderSignals
+{
+	struct Range
+	{
+		VariableChunk chunk;
+		RTLIL::SigSpec signal;
+	};
+
+	std::map<Variable, std::vector<Range>> by_variable;
+
+	void add(const VariableChunk &chunk, const RTLIL::SigSpec &signal)
+	{
+		by_variable[chunk.variable].push_back({chunk, signal});
+	}
+
+	RTLIL::SigSpec signal_for(const VariableChunk &chunk) const
+	{
+		RTLIL::SigSpec ret;
+		auto ranges_it = by_variable.find(chunk.variable);
+		log_assert(ranges_it != by_variable.end());
+		const auto &ranges = ranges_it->second;
+
+		uint64_t done = 0;
+		while (done < chunk.length) {
+			uint64_t bit = chunk.base + done;
+			auto range_it = std::upper_bound(
+					ranges.begin(), ranges.end(), bit,
+					[](uint64_t value, const Range &range) { return value < range.chunk.base; });
+			log_assert(range_it != ranges.begin());
+			range_it--;
+
+			uint64_t range_end = range_it->chunk.base + range_it->chunk.length;
+			log_assert(bit >= range_it->chunk.base);
+			log_assert(bit < range_end);
+			log_assert(range_it->signal.size() == (int)range_it->chunk.length);
+
+			uint64_t range_offset = bit - range_it->chunk.base;
+			uint64_t width = std::min(chunk.length - done, range_it->chunk.length - range_offset);
+			ret.append(range_it->signal.extract((int)range_offset, (int)width));
+			done += width;
+		}
+
+		return ret;
+	}
+};
 
 struct SwitchHelper
 {
@@ -24,7 +134,7 @@ struct SwitchHelper
 	using VariableState = ProceduralContext::VariableState;
 
 	VariableState &vstate;
-	VariableState::Map save_map;
+	VariableState::SaveState save_map;
 	std::vector<std::tuple<Case *, VariableBits, RTLIL::SigSpec>> branch_updates;
 	bool entered = false, finished = false;
 
@@ -89,23 +199,31 @@ struct SwitchHelper
 
 	void finish(NetlistContext &netlist)
 	{
-		VariableBits updated_anybranch;
+		SwitchUpdatedChunks updated_anybranch;
 		for (auto &branch : branch_updates)
-			updated_anybranch.append(std::get<1>(branch));
-		updated_anybranch.sort_and_unify();
+			updated_anybranch.add(std::get<1>(branch));
+		auto updated_chunks = updated_anybranch.chunks();
 
-		// end-of-scope variables
+		// Automatic variables that were created only inside a branch have no
+		// parent-scope value to merge into, so they do not get placeholders.
 		Yosys::pool<Variable> eos_variables;
 
-		auto &va = vstate.visible_assignments;
-		for (auto bit : updated_anybranch)
-			if (bit.variable.kind != Variable::Static && !va.count(bit))
-				eos_variables.insert(bit.variable);
+		for (auto chunk : updated_chunks) {
+			if (chunk.variable.kind == Variable::Static)
+				continue;
+			for (uint64_t i = 0; i < chunk.bitwidth(); i++)
+				if (!vstate.has_assignment(chunk[i]))
+					eos_variables.insert(chunk.variable);
+		}
 
-		for (auto chunk : updated_anybranch.chunks()) {
+		SwitchPlaceholderSignals placeholder_signals;
+
+		// Create one placeholder per merged chunk and publish it as the
+		// visible value after the switch.
+		for (auto chunk : updated_chunks) {
 			if (chunk.variable.kind != Variable::Static && eos_variables.count(chunk.variable)) {
 				for (uint64_t i = 0; i < chunk.bitwidth(); i++)
-					log_assert(!va.count(chunk[i]));
+					log_assert(!vstate.has_assignment(chunk[i]));
 
 				continue;
 			}
@@ -121,9 +239,12 @@ struct SwitchHelper
 			RTLIL::SigSpec w_default = vstate.evaluate(netlist, chunk);
 			RTLIL::SigSpec w = netlist.add_placeholder_signal(chunk.bitwidth(), name_suggestion);
 			parent->aux_actions.push_back(RTLIL::SigSig(w, w_default));
+			placeholder_signals.add(chunk, w);
 			vstate.set(chunk, w);
 		}
 
+		// Re-target each branch's original updates onto slices of the merged
+		// placeholders created above.
 		for (auto &branch : branch_updates) {
 			Case *rule;
 			VariableBits target;
@@ -137,12 +258,7 @@ struct SwitchHelper
 					continue;
 				}
 
-				// get the wire (or some part of it) which we created up above
-				RTLIL::SigSpec target_w;
-				for (uint64_t i = 0; i < chunk.bitwidth(); i++) {
-					log_assert(va.count(chunk[i]));
-					target_w.append(va.at(chunk[i]));
-				}
+				RTLIL::SigSpec target_w = placeholder_signals.signal_for(chunk);
 
 				rule->aux_actions.push_back(
 						RTLIL::SigSig(target_w, source.extract(done, (int)chunk.bitwidth())));

--- a/src/variables.cc
+++ b/src/variables.cc
@@ -162,7 +162,7 @@ bool Variable::operator<(const Variable &other) const
 			else
 				return order_symbols_within_scope(symbol, other.symbol);
 		}
-		return false;
+		return depth < other.depth;
 	} else if (kind == EscapeFlag) {
 		return id < other.id;
 	} else if (kind == Dummy) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(ALL_TESTS
     unit/expression_attrs.ys
     unit/latch.ys
     unit/selftests.tcl
+    unit/switchhelper_rank1_order.tcl
     various/assign_mixing.ys
     various/assignment_pattern_lhs.ys
     various/bb_detect.ys

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ set(ALL_TESTS
     unit/function_call.ys
     unit/expression_attrs.ys
     unit/latch.ys
+    unit/expr_bitwise_z_simplification.tcl
     unit/selftests.tcl
     unit/switchhelper_rank1_order.tcl
     various/assign_mixing.ys

--- a/tests/unit/dynamic_lhs_sparse.sv
+++ b/tests/unit/dynamic_lhs_sparse.sv
@@ -1,0 +1,419 @@
+module dynamic_lhs_bit_static_priority(
+	input logic [3:0] base,
+	input logic [1:0] sel,
+	input logic dynamic_bit,
+	input logic static_bit,
+	output logic [3:0] actual
+);
+	logic [3:0] expected;
+
+	always_comb begin
+		actual = base;
+		actual[sel] = dynamic_bit;
+		actual[1] = static_bit;
+
+		expected = base;
+		case (sel)
+			2'd0: expected[0] = dynamic_bit;
+			2'd1: expected[1] = dynamic_bit;
+			2'd2: expected[2] = dynamic_bit;
+			2'd3: expected[3] = dynamic_bit;
+		endcase
+		expected[1] = static_bit;
+
+		if (^sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module dynamic_lhs_static_dynamic_priority(
+	input logic [3:0] base,
+	input logic [1:0] sel,
+	input logic dynamic_bit,
+	input logic static_bit,
+	output logic [3:0] actual
+);
+	logic [3:0] expected;
+
+	always_comb begin
+		actual = base;
+		actual[1] = static_bit;
+		actual[sel] = dynamic_bit;
+
+		expected = base;
+		expected[1] = static_bit;
+		case (sel)
+			2'd0: expected[0] = dynamic_bit;
+			2'd1: expected[1] = dynamic_bit;
+			2'd2: expected[2] = dynamic_bit;
+			2'd3: expected[3] = dynamic_bit;
+		endcase
+
+		if (^sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module dynamic_lhs_packed_lane(
+	input logic [31:0] base_flat,
+	input logic [1:0] sel,
+	input logic [7:0] data,
+	output logic [31:0] actual_flat
+);
+	logic [3:0][7:0] base;
+	logic [3:0][7:0] actual;
+	logic [3:0][7:0] expected;
+
+	assign base = base_flat;
+	assign actual_flat = actual;
+
+	always_comb begin
+		actual = base;
+		actual[sel] = data;
+
+		expected = base;
+		case (sel)
+			2'd0: expected[0] = data;
+			2'd1: expected[1] = data;
+			2'd2: expected[2] = data;
+			2'd3: expected[3] = data;
+		endcase
+
+		if (^sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module dynamic_lhs_indexed_byte_partselect(
+	input logic [31:0] base,
+	input logic [1:0] sel,
+	input logic [7:0] data,
+	output logic [31:0] actual
+);
+	logic [31:0] expected;
+
+	always_comb begin
+		actual = base;
+		actual[{sel, 3'b000} +: 8] = data;
+
+		expected = base;
+		case (sel)
+			2'd0: expected[7:0] = data;
+			2'd1: expected[15:8] = data;
+			2'd2: expected[23:16] = data;
+			2'd3: expected[31:24] = data;
+		endcase
+
+		if (^sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module dynamic_lhs_selected_struct_field(
+	input logic [31:0] base_flat,
+	input logic [1:0] sel,
+	input logic [4:0] payload,
+	output logic [31:0] actual_flat
+);
+	typedef struct packed {
+		logic [2:0] tag;
+		logic [4:0] payload;
+	} item_t;
+
+	item_t [3:0] base;
+	item_t [3:0] actual;
+	item_t [3:0] expected;
+
+	assign base = base_flat;
+	assign actual_flat = actual;
+
+	always_comb begin
+		actual = base;
+		actual[sel].payload = payload;
+
+		expected = base;
+		case (sel)
+			2'd0: expected[0].payload = payload;
+			2'd1: expected[1].payload = payload;
+			2'd2: expected[2].payload = payload;
+			2'd3: expected[3].payload = payload;
+		endcase
+
+		if (^sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module dynamic_lhs_branch_updates(
+	input logic [7:0] base,
+	input logic choose,
+	input logic [2:0] sel_a,
+	input logic [2:0] sel_b,
+	input logic bit_a,
+	input logic bit_b,
+	output logic [7:0] actual
+);
+	logic [7:0] expected;
+
+	always_comb begin
+		actual = base;
+		if (choose)
+			actual[sel_a] = bit_a;
+		else
+			actual[sel_b] = bit_b;
+
+		expected = base;
+		if (choose) begin
+			case (sel_a)
+				3'd0: expected[0] = bit_a;
+				3'd1: expected[1] = bit_a;
+				3'd2: expected[2] = bit_a;
+				3'd3: expected[3] = bit_a;
+				3'd4: expected[4] = bit_a;
+				3'd5: expected[5] = bit_a;
+				3'd6: expected[6] = bit_a;
+				3'd7: expected[7] = bit_a;
+			endcase
+		end else begin
+			case (sel_b)
+				3'd0: expected[0] = bit_b;
+				3'd1: expected[1] = bit_b;
+				3'd2: expected[2] = bit_b;
+				3'd3: expected[3] = bit_b;
+				3'd4: expected[4] = bit_b;
+				3'd5: expected[5] = bit_b;
+				3'd6: expected[6] = bit_b;
+				3'd7: expected[7] = bit_b;
+			endcase
+		end
+
+		if (choose !== 1'bx && ^sel_a !== 1'bx && ^sel_b !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module dynamic_lhs_branch_absent_restore(
+	input logic [7:0] base,
+	input logic enable,
+	input logic [2:0] sel,
+	input logic data,
+	output logic [7:0] actual
+);
+	logic [7:0] expected;
+
+	always_comb begin
+		actual = base;
+		if (enable)
+			actual[sel] = data;
+
+		expected = base;
+		if (enable) begin
+			case (sel)
+				3'd0: expected[0] = data;
+				3'd1: expected[1] = data;
+				3'd2: expected[2] = data;
+				3'd3: expected[3] = data;
+				3'd4: expected[4] = data;
+				3'd5: expected[5] = data;
+				3'd6: expected[6] = data;
+				3'd7: expected[7] = data;
+			endcase
+		end
+
+		if (enable !== 1'bx && ^sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module dynamic_lhs_overlap_priority(
+	input logic [6:0] base,
+	input logic [1:0] sel,
+	input logic [2:0] data,
+	input logic override_bit,
+	output logic [6:0] actual
+);
+	logic [6:0] expected;
+
+	always_comb begin
+		actual = base;
+		actual[sel +: 3] = data;
+		actual[sel + 1] = override_bit;
+
+		expected = base;
+		case (sel)
+			2'd0: expected[2:0] = data;
+			2'd1: expected[3:1] = data;
+			2'd2: expected[4:2] = data;
+			2'd3: expected[5:3] = data;
+		endcase
+		case (sel)
+			2'd0: expected[1] = override_bit;
+			2'd1: expected[2] = override_bit;
+			2'd2: expected[3] = override_bit;
+			2'd3: expected[4] = override_bit;
+		endcase
+
+		if (^sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module dynamic_lhs_nonzero_vector_range(
+	input logic [4:1] base,
+	input logic [1:0] sel,
+	input logic data,
+	output logic [4:1] actual
+);
+	logic [4:1] expected;
+
+	always_comb begin
+		actual = base;
+		actual[sel + 1] = data;
+
+		expected = base;
+		case (sel)
+			2'd0: expected[1] = data;
+			2'd1: expected[2] = data;
+			2'd2: expected[3] = data;
+			2'd3: expected[4] = data;
+		endcase
+
+		if (^sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module dynamic_lhs_descending_array_lane(
+	input logic [15:0] base_flat,
+	input logic [1:0] sel,
+	input logic [3:0] data,
+	output logic [15:0] actual_flat
+);
+	logic [1:4][3:0] base;
+	logic [1:4][3:0] actual;
+	logic [1:4][3:0] expected;
+
+	assign base = base_flat;
+	assign actual_flat = actual;
+
+	always_comb begin
+		actual = base;
+		actual[sel + 1] = data;
+
+		expected = base;
+		case (sel)
+			2'd0: expected[1] = data;
+			2'd1: expected[2] = data;
+			2'd2: expected[3] = data;
+			2'd3: expected[4] = data;
+		endcase
+
+		if (^sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module dynamic_lhs_chunk_boundary(
+	input logic [129:0] base,
+	input logic [7:0] sel,
+	input logic data,
+	output logic [129:0] actual
+);
+	logic [129:0] selected;
+	logic [129:0] expected;
+
+	always_comb begin
+		actual = base;
+		actual[sel] = data;
+
+		selected = 130'b1 << sel;
+		expected = (base & ~selected) | ({130{data}} & selected);
+
+		if (^sel !== 1'bx) begin
+			if (sel < 8'd130)
+				assert(actual === expected);
+			else
+				assert(actual === base);
+		end
+	end
+endmodule
+
+module dynamic_lhs_block_boundary(
+	input logic [256:0] base,
+	input logic [8:0] sel,
+	input logic data,
+	output logic [256:0] actual
+);
+	logic [256:0] selected;
+	logic [256:0] expected;
+
+	always_comb begin
+		actual = base;
+		actual[sel] = data;
+
+		selected = 257'b1 << sel;
+		expected = (base & ~selected) | ({257{data}} & selected);
+
+		if (^sel !== 1'bx) begin
+			if (sel < 9'd257)
+				assert(actual === expected);
+			else
+				assert(actual === base);
+		end
+	end
+endmodule
+
+module dynamic_lhs_wide_lane_multi_block(
+	input logic [1151:0] base_flat,
+	input logic [2:0] sel,
+	input logic [143:0] data,
+	output logic [1151:0] actual_flat
+);
+	logic [7:0][143:0] base;
+	logic [7:0][143:0] actual;
+	logic [7:0][143:0] expected;
+
+	assign base = base_flat;
+	assign actual_flat = actual;
+
+	always_comb begin
+		actual = base;
+		actual[sel] = data;
+
+		expected = base;
+		case (sel)
+			3'd0: expected[0] = data;
+			3'd1: expected[1] = data;
+			3'd2: expected[2] = data;
+			3'd3: expected[3] = data;
+			3'd4: expected[4] = data;
+			3'd5: expected[5] = data;
+			3'd6: expected[6] = data;
+			3'd7: expected[7] = data;
+		endcase
+
+		if (^sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module dynamic_lhs_narrow_selector_no_alias(
+	input logic [191:0] base,
+	input logic [5:0] sel,
+	input logic data,
+	output logic [191:0] actual
+);
+	logic [63:0] selected;
+	logic [191:0] expected;
+
+	always_comb begin
+		actual = base;
+		actual[sel] = data;
+
+		selected = 64'b1 << sel;
+		expected = {base[191:64], (base[63:0] & ~selected) | ({64{data}} & selected)};
+
+		if (^sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule

--- a/tests/unit/expr_bitwise_z_simplification.tcl
+++ b/tests/unit/expr_bitwise_z_simplification.tcl
@@ -1,0 +1,50 @@
+yosys -import
+
+set sv_source {
+module expr_bitwise_z_simplification(
+	input logic dynamic_bit
+);
+	wire [1:0] and_equal = {1'bz, dynamic_bit} & {1'bz, dynamic_bit};
+	wire [1:0] or_equal = {1'bz, dynamic_bit} | {1'bz, dynamic_bit};
+	wire [1:0] and_one_left = {1'bz, dynamic_bit} & 2'b11;
+	wire [1:0] and_one_right = 2'b11 & {1'bz, dynamic_bit};
+	wire [1:0] or_zero_left = {1'bz, dynamic_bit} | 2'b00;
+	wire [1:0] or_zero_right = 2'b00 | {1'bz, dynamic_bit};
+endmodule
+}
+
+set sv_file [file join /tmp "yosys_slang_expr_bitwise_z_simplification_[pid].sv"]
+set sv_fd [open $sv_file w]
+puts -nonewline $sv_fd $sv_source
+close $sv_fd
+
+read_slang $sv_file
+file delete -force $sv_file
+
+set dump_file [file join /tmp "yosys_slang_expr_bitwise_z_simplification_[pid].il"]
+write_rtlil $dump_file
+
+set fd [open $dump_file r]
+set rtlil [read $fd]
+close $fd
+file delete -force $dump_file
+
+proc reject_preserved_z_result {rtlil signal} {
+	set preserved_z [format {connect \A { 1'z \dynamic_bit }
+    connect \Y \%s} $signal]
+
+	if {[string first $preserved_z $rtlil] >= 0} {
+		error "bitwise simplification preserved 1'bz in $signal instead of producing unknown"
+	}
+}
+
+foreach signal {
+	and_equal
+	or_equal
+	and_one_left
+	and_one_right
+	or_zero_left
+	or_zero_right
+} {
+	reject_preserved_z_result $rtlil $signal
+}

--- a/tests/unit/expr_boolean_cone.sv
+++ b/tests/unit/expr_boolean_cone.sv
@@ -1,0 +1,62 @@
+module expr_boolean_cone_1bit(
+	input logic a,
+	input logic b,
+	input logic c,
+	input logic d
+);
+	wire and_chain = ((a & b) & c) & d;
+	wire or_chain = ((a | b) | c) | d;
+	wire dup_chain = (a & b) | (a & b);
+	wire mixed_not = (~(a & b)) | c;
+
+	always_comb begin
+		if (a === 1'b0 || b === 1'b0 || c === 1'b0 || d === 1'b0)
+			assert(and_chain === 1'b0);
+		if (a === 1'b1 && b === 1'b1 && c === 1'b1 && d === 1'b1)
+			assert(and_chain === 1'b1);
+		if (a === 1'bx && b === 1'b1 && c === 1'b1 && d === 1'b1)
+			assert(and_chain === 1'bx);
+
+		if (a === 1'b1 || b === 1'b1 || c === 1'b1 || d === 1'b1)
+			assert(or_chain === 1'b1);
+		if (a === 1'b0 && b === 1'b0 && c === 1'b0 && d === 1'b0)
+			assert(or_chain === 1'b0);
+		if (a === 1'bx && b === 1'b0 && c === 1'b0 && d === 1'b0)
+			assert(or_chain === 1'bx);
+
+		if (a === 1'b0 || b === 1'b0)
+			assert(dup_chain === 1'b0);
+		if (a === 1'b1 && b === 1'b1)
+			assert(dup_chain === 1'b1);
+		if (a === 1'bx && b === 1'b1)
+			assert(dup_chain === 1'bx);
+
+		if (a === 1'b1 && b === 1'b1 && c === 1'b0)
+			assert(mixed_not === 1'b0);
+		if (a === 1'b0 && c === 1'b0)
+			assert(mixed_not === 1'b1);
+		if (a === 1'bx && b === 1'b1 && c === 1'b0)
+			assert(mixed_not === 1'bx);
+	end
+endmodule
+
+module expr_boolean_cone_multibit(
+	input logic [3:0] a,
+	input logic [3:0] b,
+	input logic [3:0] c
+);
+	wire [3:0] actual_and = a & b & c;
+	wire [3:0] actual_or = a | b | c;
+	logic [3:0] expected_and;
+	logic [3:0] expected_or;
+
+	always_comb begin
+		for (int i = 0; i < 4; i++) begin
+			expected_and[i] = a[i] & b[i] & c[i];
+			expected_or[i] = a[i] | b[i] | c[i];
+		end
+
+		assert(actual_and === expected_and);
+		assert(actual_or === expected_or);
+	end
+endmodule

--- a/tests/unit/expr_wide_bitwise_semantics.sv
+++ b/tests/unit/expr_wide_bitwise_semantics.sv
@@ -1,0 +1,54 @@
+module expr_wide_bitwise_semantics(
+	input logic [3:0] a,
+	input logic [3:0] b
+);
+	wire [3:0] actual_and = a & b;
+	wire [3:0] actual_and_commuted = b & a;
+	wire [3:0] actual_or = a | b;
+	wire [3:0] actual_or_commuted = b | a;
+	wire [3:0] actual_xor = a ^ b;
+	wire [3:0] actual_xor_commuted = b ^ a;
+	wire [3:0] actual_xnor = a ~^ b;
+	wire [3:0] actual_not = ~a;
+
+	logic [3:0] expected_and;
+	logic [3:0] expected_or;
+	logic [3:0] expected_xor;
+	logic [3:0] expected_xnor;
+	logic [3:0] expected_not;
+
+	always_comb begin
+		for (int i = 0; i < 4; i++) begin
+			expected_and[i] = a[i] & b[i];
+			expected_or[i] = a[i] | b[i];
+			expected_xor[i] = a[i] ^ b[i];
+			expected_xnor[i] = ~(a[i] ^ b[i]);
+			expected_not[i] = ~a[i];
+
+			if (a[i] === 1'bx && b[i] === 1'b0) begin
+				assert(actual_and[i] === 1'b0);
+				assert(actual_or[i] === 1'bx);
+				assert(actual_xor[i] === 1'bx);
+				assert(actual_xnor[i] === 1'bx);
+				assert(actual_not[i] === 1'bx);
+			end
+
+			if (a[i] === 1'bx && b[i] === 1'b1) begin
+				assert(actual_and[i] === 1'bx);
+				assert(actual_or[i] === 1'b1);
+				assert(actual_xor[i] === 1'bx);
+				assert(actual_xnor[i] === 1'bx);
+				assert(actual_not[i] === 1'bx);
+			end
+		end
+
+		assert(actual_and === expected_and);
+		assert(actual_and_commuted === expected_and);
+		assert(actual_or === expected_or);
+		assert(actual_or_commuted === expected_or);
+		assert(actual_xor === expected_xor);
+		assert(actual_xor_commuted === expected_xor);
+		assert(actual_xnor === expected_xnor);
+		assert(actual_not === expected_not);
+	end
+endmodule

--- a/tests/unit/expression_attrs.ys
+++ b/tests/unit/expression_attrs.ys
@@ -3,16 +3,23 @@ module expression_attrs(
 	input logic a,
 	input logic b,
 	input logic c,
+	input logic [3:0] a4,
+	input logic [3:0] b4,
 	output logic y,
 	output logic z,
-	output logic w
+	output logic w,
+	output logic [3:0] wide_and_src,
+	output logic [3:0] wide_xor_src
 );
 	assign y = a & b;
 	assign z = a ? b : c;
 	assign w = ~a;
+	assign wide_and_src = a4 & b4;
+	assign wide_xor_src = a4 ^ b4;
 endmodule
 EOF
 
-select -assert-count 1 t:$and A:src %i
+select -assert-count 2 t:$and A:src %i
 select -assert-count 1 t:$mux A:src %i
 select -assert-count 1 t:$not A:src %i
+select -assert-count 1 t:$xor A:src %i

--- a/tests/unit/static_element_select.sv
+++ b/tests/unit/static_element_select.sv
@@ -9,7 +9,9 @@ module static_element_select_vector_base #(
 	localparam integer OFFSET = (MSB > LSB) ? (IDX - LSB) : (LSB - IDX);
 
 	wire actual = data[IDX];
-	wire expected = data >> OFFSET;
+	wire [WIDTH-1:0] shifted = data >> OFFSET;
+	wire [WIDTH-1:0] low_bit_mask = {{(WIDTH-1){1'b0}}, 1'b1};
+	wire expected = |(shifted & low_bit_mask);
 
 	always_comb
 		assert(actual === expected);
@@ -51,7 +53,12 @@ module static_element_select_array_base #(
 	localparam integer TOTAL_WIDTH = ELEMENTS * 2;
 
 	wire [1:0] actual = data[IDX];
-	wire [1:0] expected = data >> (OFFSET * 2);
+	wire [TOTAL_WIDTH-1:0] shifted = data >> (OFFSET * 2);
+	wire [TOTAL_WIDTH-1:0] low_bit_mask = {{(TOTAL_WIDTH-1){1'b0}}, 1'b1};
+	wire [1:0] expected = {
+		|((shifted >> 1) & low_bit_mask),
+		|(shifted & low_bit_mask)
+	};
 
 	always_comb
 		assert(actual === expected);
@@ -67,4 +74,27 @@ module static_element_select_array_big(
 	input logic [0:6] [1:0] data
 );
 	static_element_select_array_base #(.MSB(0), .LSB(6), .IDX(5)) t(.*);
+endmodule
+
+module static_element_select_struct_member(
+	input logic [2:0] top,
+	input logic [1:0] mid,
+	input logic low
+);
+	typedef struct packed {
+		logic [2:0] top;
+		logic [1:0] mid;
+		logic low;
+	} static_select_struct_t;
+
+	static_select_struct_t value;
+	wire actual_top = value.top[1];
+	wire actual_mid = value.mid[0];
+
+	assign value = '{top: top, mid: mid, low: low};
+
+	always_comb begin
+		assert(actual_top === top[1]);
+		assert(actual_mid === mid[0]);
+	end
 endmodule

--- a/tests/unit/static_rhs_fastpath.sv
+++ b/tests/unit/static_rhs_fastpath.sv
@@ -1,0 +1,107 @@
+typedef struct packed {
+	logic [1:0] tag;
+	logic [1:0][3:0] lanes;
+	logic [2:0] tail;
+} static_rhs_packet_t;
+
+typedef logic [12:0] static_rhs_bits_t;
+typedef logic signed [7:0] static_rhs_signed_byte_t;
+typedef logic [7:0] static_rhs_unsigned_byte_t;
+
+module static_rhs_member_select_chain(
+	input logic [1:0] tag,
+	input logic [1:0][3:0] lanes,
+	input logic [2:0] tail
+);
+	static_rhs_packet_t packet;
+	static_rhs_packet_t packet_again;
+
+	assign packet = '{tag: tag, lanes: lanes, tail: tail};
+
+	wire [7:0] actual = {
+		packet.tag[0],
+		packet.lanes[1][2:1],
+		packet.lanes[0][3],
+		packet.tail[2:1],
+		packet.lanes[0][0],
+		packet.tail[0]
+	};
+	wire [7:0] expected = {
+		tag[0],
+		lanes[1][2:1],
+		lanes[0][3],
+		tail[2:1],
+		lanes[0][0],
+		tail[0]
+	};
+
+	wire [12:0] packet_bits = static_rhs_bits_t'(packet);
+	wire [12:0] expected_bits = {tag, lanes[1], lanes[0], tail};
+	assign packet_again = static_rhs_packet_t'(packet_bits);
+
+	always_comb begin
+		assert(actual === expected);
+		assert(packet_bits === expected_bits);
+		assert(packet_again.tag === tag);
+		assert(packet_again.lanes[1] === lanes[1]);
+		assert(packet_again.lanes[0] === lanes[0]);
+		assert(packet_again.tail === tail);
+	end
+endmodule
+
+module static_rhs_same_width_vector_cast(
+	input logic [7:0] data
+);
+	wire signed [7:0] signed_data = static_rhs_signed_byte_t'(data);
+	wire [7:0] unsigned_data = static_rhs_unsigned_byte_t'(signed_data);
+
+	always_comb
+		assert(unsigned_data === data);
+endmodule
+
+module static_rhs_dynamic_select_fallback(
+	input logic [7:0] data,
+	input logic [3:0] bit_sel,
+	input logic [3:0] base_sel
+);
+	wire actual_bit = data[bit_sel];
+	wire [1:0] actual_part = data[base_sel +: 2];
+	logic expected_bit;
+	logic [1:0] expected_part;
+
+	always_comb begin
+		expected_bit = 1'bx;
+		expected_part = 2'bxx;
+
+		if (^bit_sel !== 1'bx) begin
+			case (bit_sel)
+				3'd0: expected_bit = data[0];
+				3'd1: expected_bit = data[1];
+				3'd2: expected_bit = data[2];
+				3'd3: expected_bit = data[3];
+				3'd4: expected_bit = data[4];
+				3'd5: expected_bit = data[5];
+				3'd6: expected_bit = data[6];
+				3'd7: expected_bit = data[7];
+				default: expected_bit = 1'bx;
+			endcase
+		end
+
+		if (^base_sel !== 1'bx) begin
+			case (base_sel)
+				3'd0: expected_part = {data[1], data[0]};
+				3'd1: expected_part = {data[2], data[1]};
+				3'd2: expected_part = {data[3], data[2]};
+				3'd3: expected_part = {data[4], data[3]};
+				3'd4: expected_part = {data[5], data[4]};
+				3'd5: expected_part = {data[6], data[5]};
+				3'd6: expected_part = {data[7], data[6]};
+				3'd7: expected_part = {1'bx, data[7]};
+				default: expected_part = 2'bxx;
+			endcase
+		end
+
+		assert(actual_bit === expected_bit);
+		assert(actual_part === expected_part);
+	end
+endmodule

--- a/tests/unit/switchhelper_rank1.sv
+++ b/tests/unit/switchhelper_rank1.sv
@@ -1,0 +1,160 @@
+module switchhelper_rank1_alignment(
+	input logic sel,
+	input logic [7:0] seed
+);
+	logic [7:0] actual;
+	logic [7:0] expected;
+
+	always_comb begin
+		actual = seed;
+		expected = seed;
+
+		if (sel) begin
+			{actual[0], actual[7], actual[3:2]} = {seed[6], seed[1], seed[5:4]};
+			expected[0] = seed[6];
+			expected[7] = seed[1];
+			expected[3:2] = seed[5:4];
+		end else begin
+			{actual[6:5], actual[1]} = {seed[2:1], seed[7]};
+			expected[6:5] = seed[2:1];
+			expected[1] = seed[7];
+		end
+
+		if (sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module switchhelper_rank1_partial_overlap(
+	input logic sel,
+	input logic [7:0] base,
+	input logic [5:0] hi,
+	input logic [5:0] lo
+);
+	logic [7:0] actual;
+	logic [7:0] expected;
+
+	always_comb begin
+		actual = base;
+		expected = base;
+
+		if (sel) begin
+			actual[7:2] = hi;
+			expected[7:2] = hi;
+		end else begin
+			actual[5:0] = lo;
+			expected[5:0] = lo;
+		end
+
+		if (sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module switchhelper_rank1_automatic_eos(
+	input logic sel,
+	input logic [3:0] a,
+	input logic [3:0] b
+);
+	logic [3:0] actual;
+	logic [3:0] expected;
+
+	always_comb begin
+		actual = 4'h0;
+
+		if (sel) begin
+			automatic logic [3:0] tmp;
+			tmp = {a[0], a[3:1]};
+			actual = tmp;
+		end else begin
+			automatic logic [3:0] tmp;
+			tmp = {b[2:0], b[3]};
+			actual = tmp;
+		end
+
+		expected = sel ? {a[0], a[3:1]} : {b[2:0], b[3]};
+
+		if (sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module switchhelper_rank1_order(
+	input logic [1:0] sel,
+	input logic [7:0] a,
+	input logic [7:0] b,
+	input logic [7:0] c,
+	output logic [7:0] y
+);
+	always_comb begin
+		y = a;
+		case (sel)
+			2'b00: begin
+				y[7:2] = b[5:0];
+			end
+			2'b01: begin
+				{y[1], y[6:5], y[3]} = {c[7], c[2:1], c[0]};
+			end
+			2'b10: begin
+				y[5:0] = c[5:0];
+			end
+			default: begin
+				y[4:2] = b[7:5];
+			end
+		endcase
+	end
+endmodule
+
+module switchhelper_rank1_reentrant_automatic_local(
+	input logic sel,
+	input logic [5:0] seed
+);
+	logic [5:0] actual;
+	logic [5:0] expected;
+
+	function automatic logic [5:0] recurse(input logic [1:0] n, input logic [5:0] value);
+		automatic logic [5:0] tmp;
+		automatic logic [5:0] child;
+		begin
+			tmp = value ^ {4'b0000, n};
+			if (n != 0) begin
+				if (sel) begin
+					child = recurse(n - 2'd1, tmp + 6'd3);
+					tmp = tmp ^ {child[2:0], child[5:3]};
+				end else begin
+					child = recurse(n - 2'd1, tmp + 6'd5);
+					tmp = tmp + {child[0], child[5:1]};
+				end
+			end
+			recurse = tmp;
+		end
+	endfunction
+
+	always_comb begin
+		logic [5:0] f2_tmp;
+		logic [5:0] f2_child;
+		logic [5:0] f1_input;
+		logic [5:0] f1_tmp;
+		logic [5:0] f1_child;
+
+		actual = recurse(2'd2, seed);
+
+		f2_tmp = seed ^ 6'd2;
+		if (sel) begin
+			f1_input = f2_tmp + 6'd3;
+			f1_tmp = f1_input ^ 6'd1;
+			f1_child = (f1_tmp + 6'd3) ^ 6'd0;
+			f2_child = f1_tmp ^ {f1_child[2:0], f1_child[5:3]};
+			expected = f2_tmp ^ {f2_child[2:0], f2_child[5:3]};
+		end else begin
+			f1_input = f2_tmp + 6'd5;
+			f1_tmp = f1_input ^ 6'd1;
+			f1_child = (f1_tmp + 6'd5) ^ 6'd0;
+			f2_child = f1_tmp + {f1_child[0], f1_child[5:1]};
+			expected = f2_tmp + {f2_child[0], f2_child[5:1]};
+		end
+
+		if (sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule

--- a/tests/unit/switchhelper_rank1_order.tcl
+++ b/tests/unit/switchhelper_rank1_order.tcl
@@ -1,0 +1,40 @@
+yosys -import
+
+set sv_file [file join [pwd] switchhelper_rank1.sv]
+set first_dump [file join /tmp "yosys_slang_switchhelper_rank1_order_[pid]_a.il"]
+set second_dump [file join /tmp "yosys_slang_switchhelper_rank1_order_[pid]_b.il"]
+
+proc dump_order_test {sv_file dump_file} {
+	design -reset
+	# This test covers frontend-generated process ordering, not Yosys's
+	# version-specific proc lowering order.
+	read_slang --no-proc $sv_file
+	hierarchy -top switchhelper_rank1_order
+	write_rtlil $dump_file
+}
+
+proc normalized_rtlil {dump_file} {
+	set fd [open $dump_file r]
+	set text [read $fd]
+	close $fd
+
+	# A single Yosys process intentionally keeps allocating fresh internal
+	# auto names across design resets. Normalize those IDs while preserving the
+	# generated port, statement, cell, wire, and connection ordering.
+	regsub -all {autoidx [0-9]+} $text {autoidx <N>} text
+	regsub -all {\$procmux\$[0-9]+} $text {$procmux$<N>} text
+	regsub -all {\$[0-9]+} $text {$<N>} text
+	return $text
+}
+
+dump_order_test $sv_file $first_dump
+dump_order_test $sv_file $second_dump
+
+set first_text [normalized_rtlil $first_dump]
+set second_text [normalized_rtlil $second_dump]
+
+file delete -force $first_dump $second_dump
+
+if {$first_text ne $second_text} {
+	error "switchhelper_rank1_order RTLIL output changed between identical reads"
+}

--- a/tests/unit/variablestate_rank23.sv
+++ b/tests/unit/variablestate_rank23.sv
@@ -1,0 +1,139 @@
+module variablestate_rank2_repeated_write(
+	input logic sel,
+	input logic [7:0] base,
+	input logic [7:0] a,
+	input logic [7:0] b
+);
+	logic [7:0] actual;
+	logic [7:0] expected;
+
+	always_comb begin
+		actual = base;
+		expected = base;
+
+		if (sel) begin
+			actual[5:1] = a[4:0];
+			actual[5:1] = b[4:0];
+			expected[5:1] = b[4:0];
+		end else begin
+			actual[7:3] = a[7:3];
+			expected[7:3] = a[7:3];
+		end
+
+		if (sel !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module variablestate_rank2_nested_branch(
+	input logic outer,
+	input logic inner,
+	input logic [9:0] base,
+	input logic [5:0] a,
+	input logic [5:0] b,
+	input logic [5:0] c
+);
+	logic [9:0] actual;
+	logic [9:0] expected;
+
+	always_comb begin
+		actual = base;
+		expected = base;
+
+		if (outer) begin
+			actual[7:2] = a;
+			expected[7:2] = a;
+
+			if (inner) begin
+				actual[5:0] = b;
+				expected[5:0] = b;
+			end else begin
+				actual[9:4] = c;
+				expected[9:4] = c;
+			end
+		end else begin
+			actual[8:3] = c;
+			expected[8:3] = c;
+		end
+
+		if (outer !== 1'bx && inner !== 1'bx)
+			assert(actual === expected);
+	end
+endmodule
+
+module variablestate_rank2_masked_overlap(
+	input logic [1:0] sel,
+	input logic [7:0] base,
+	input logic [3:0] data
+);
+	logic [7:0] actual;
+	logic [7:0] expected;
+
+	always_comb begin
+		actual = base;
+		expected = base;
+
+		actual[sel +: 4] = data;
+
+		if (^sel !== 1'bx) begin
+			for (int i = 0; i < 4; i++)
+				expected[sel + i] = data[i];
+			assert(actual === expected);
+		end
+	end
+endmodule
+
+module variablestate_rank23_sparse_fields(
+	input logic [3:0] valid,
+	output logic [31:0] packed_entries
+);
+	typedef struct packed {
+		logic [6:0] payload;
+		logic valid;
+	} entry_t;
+
+	entry_t [3:0] entries;
+
+	always_comb begin
+		for (int i = 0; i < 4; i++)
+			entries[i].valid = valid[i];
+
+		packed_entries = entries;
+
+		assert(packed_entries[0] === valid[0]);
+		assert(packed_entries[8] === valid[1]);
+		assert(packed_entries[16] === valid[2]);
+		assert(packed_entries[24] === valid[3]);
+	end
+endmodule
+
+module variablestate_rank3_mixed_static_visible(
+	input logic [7:0] data,
+	output logic [15:0] value,
+	output logic [11:0] slice
+);
+	always_comb begin
+		value[11:4] = data;
+		slice = value[13:2];
+
+		assert(slice[0] === value[2]);
+		assert(slice[1] === value[3]);
+		assert(slice[9:2] === data);
+		assert(slice[10] === value[12]);
+		assert(slice[11] === value[13]);
+	end
+endmodule
+
+module variablestate_rank3_static_miss(
+	input logic [15:0] a,
+	input logic [15:0] b,
+	output logic [15:0] actual
+);
+	assign actual[15:8] = b[15:8];
+
+	always_comb begin
+		actual[7:0] = a[7:0];
+
+		assert(actual === {b[15:8], a[7:0]});
+	end
+endmodule

--- a/tests/various/mem_inference.ys
+++ b/tests/various/mem_inference.ys
@@ -69,3 +69,24 @@ endmodule
 EOF
 memory_collect
 select -assert-none t:$mem_v2
+
+design -reset
+read_slang <<EOF
+module top(
+	input clk,
+	input [1:0] a,
+	input [7:0] data,
+	output [7:0] q_const,
+	output [7:0] q_dyn
+);
+	reg [7:0] x[0:3];
+
+	assign q_const = x[2];
+	assign q_dyn = x[a];
+
+	always @(posedge clk)
+		x[a] <= data;
+endmodule
+EOF
+memory_collect
+select -assert-count 1 t:$mem_v2 r:RD_PORTS=2 %i


### PR DESCRIPTION

Add a bounded dynamic-LHS lowering path for dynamic element-like writes whose inner lvalue is static. Instead of building a full-width demux mask for the entire target, split the possible target into fixed-size windows and update each window with a block-local mask.

Move contiguous selector-window construction into RTLILBuilder::DemuxWindow(), with small builder-side guardrails for zero demux inputs and identical mux branches. AddressingResolver now only clips the requested element window to the signed selector range and delegates branch-window emission to the builder.

Add dynamic_lhs_sparse.sv coverage for priority ordering, packed lanes, indexed part-select fallback, selected struct fields, branch-local updates, absent restore, nonzero and descending ranges, block boundaries, wide lanes, and narrow selectors.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/povik/yosys-slang/pull/339).
* __->__ #339
* #338
* #337
* #336
* #335
* #334
* #333
* #332