### PR TITLE
Fix unsupported cell type segmentation fault

### DIFF
--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -2650,7 +2650,7 @@ public:
 		auto id = (!sym.name.compare("")) ? netlist.new_id() : netlist.id(sym);
 		RTLIL::IdString op;
 		bool inv_y = false;
-		RTLIL::Cell *cell;
+		RTLIL::Cell *cell = nullptr;
 		ast_invariant(sym, ports.front()->kind == ast::ExpressionKind::Assignment);
 		auto &assign = ports.front()->as<ast::AssignmentExpression>();
 		auto y = netlist.eval.connection_lhs(assign);
@@ -2795,10 +2795,16 @@ public:
 					cell = pmos; // transfer_attrs to pmos after switch block
 				} else {
 					// bidir (tran/rtran/tranif0/rtranif0/tranif1/rtranif1) are unsupported
-					netlist.add_diag(diag::PrimTypeUnsupported, sym.location);
+					netlist.add_diag(diag::PrimTypeUnsupported, sym.location) << type;
 				}
 			}
 		}
+
+		if (!cell) {
+			// We've encountered an error - let's stop right here
+			return;
+		}
+
 		cell->fixup_parameters();
 		transfer_attrs(netlist, sym, cell);
 		if (inv_y) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,6 +65,7 @@ set(ALL_TESTS
     various/stringattrs.ys
     various/stringparams.ys
     various/timescale.ys
+    various/tranif.ys
     various/top_attr.ys
     various/unknown_cells.ys
     various/toplevel_intf_unsupported.ys

--- a/tests/various/tranif.ys
+++ b/tests/various/tranif.ys
@@ -1,0 +1,8 @@
+test_slangdiag -expect "primitives of type 'tranif1' unsupported"
+read_slang <<EOF
+// 28. Gate-level and switch-level modeling
+// 28.8. Bidirectional pass switches
+module top (inout control, inout inout1, inout inout2);
+  tranif1 t1 (inout1,inout2,control);
+endmodule
+EOF


### PR DESCRIPTION
Hi all,

This PR fixes a segfault in `yosys-slang` that occurs when an unsupported cell type (e.g. `tranif`) is encountered.

It also improves the diagnostic by reporting the unsupported cell type.