### PR TITLE
Break out the slang vendored source into its own module extension.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,15 +1,15 @@
 """yosys-slang plugin: builds slang.so against @yosys//:hdrs.
-
-slang and fmt are vendored as git submodules under third_party/. The
-diagnostic_gen.py / syntax_gen.py codegen mirrors what slang's own
-cmake runs at build time. SLANG_VERSION_PATCH/HASH are stubbed (cmake
-derives them from `git describe`); refine with a workspace-status hook
-if needed.
 """
 
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_license//rules:license.bzl", "license")
+load(
+    "//:dependency_support/slang_ext.bzl",
+    "SLANG_VERSION_MAJOR",
+    "SLANG_VERSION_MINOR",
+    "SLANG_VERSION_PATCH",
+)
 
 package(
     default_applicable_licenses = [":license"],
@@ -24,202 +24,9 @@ license(
     license_text = "LICENSE",
 )
 
-# Bundled slang and fmt are vendored under their own (MIT) licenses.
-
-license(
-    name = "license_slang",
-    package_name = "slang",
-    license_kinds = ["@rules_license//licenses/spdx:MIT"],
-    license_text = "third_party/slang/LICENSE",
-)
-
-license(
-    name = "license_fmt",
-    package_name = "fmt",
-    license_kinds = ["@rules_license//licenses/spdx:MIT"],
-    license_text = "third_party/fmt/LICENSE",
-)
-
-# Version of the slang library tracked in third_party/slang.
-# Bump when the submodule is updated. SLANG_VERSION_PATCH/HASH are
-# normally derived from `git describe`; left as 0/"unknown" here since
-# the submodule is checked out detached.
-SLANG_VERSION_MAJOR = 10
-SLANG_VERSION_MINOR = 0
-SLANG_VERSION_PATCH = 0
-SLANG_VERSION_HASH = "unknown"
-
 # yosys-slang's own revision string is taken from MODULE.bazel's
 # version field (set by the BCR submitter at release time).
 YOSYS_SLANG_REVISION = module_version() or "unknown"
-
-# --- Generated export header (static build = no-op) ---
-
-genrule(
-    name = "slang_export_h",
-    outs = ["slang/slang_export.h"],
-    cmd = """cat > $@ << 'HEADER'
-#pragma once
-#define SLANG_EXPORT
-#define SLANG_NO_EXPORT
-HEADER""",
-)
-
-expand_template(
-    name = "slang_version_cpp",
-    out = "VersionInfo.cpp",
-    substitutions = {
-        "@SLANG_VERSION_MAJOR@": str(SLANG_VERSION_MAJOR),
-        "@SLANG_VERSION_MINOR@": str(SLANG_VERSION_MINOR),
-        "@SLANG_VERSION_PATCH@": str(SLANG_VERSION_PATCH),
-        "@SLANG_VERSION_HASH@": SLANG_VERSION_HASH,
-    },
-    template = "third_party/slang/source/util/VersionInfo.cpp.in",
-)
-
-# --- Code generation for slang ---
-
-genrule(
-    name = "slang_diag_gen",
-    srcs = [
-        "third_party/slang/scripts/diagnostic_gen.py",
-        "third_party/slang/scripts/diagnostics.txt",
-    ] + glob([
-        "third_party/slang/source/**/*.cpp",
-        "third_party/slang/include/slang/**/*.h",
-    ]),
-    outs = [
-        "DiagCode.cpp",
-        "slang/diagnostics/AllDiags.h",
-        "slang/diagnostics/AnalysisDiags.h",
-        "slang/diagnostics/CompilationDiags.h",
-        "slang/diagnostics/ConstEvalDiags.h",
-        "slang/diagnostics/DeclarationsDiags.h",
-        "slang/diagnostics/ExpressionsDiags.h",
-        "slang/diagnostics/GeneralDiags.h",
-        "slang/diagnostics/LexerDiags.h",
-        "slang/diagnostics/LookupDiags.h",
-        "slang/diagnostics/MetaDiags.h",
-        "slang/diagnostics/NumericDiags.h",
-        "slang/diagnostics/ParserDiags.h",
-        "slang/diagnostics/PreprocessorDiags.h",
-        "slang/diagnostics/StatementsDiags.h",
-        "slang/diagnostics/SysFuncsDiags.h",
-        "slang/diagnostics/TypesDiags.h",
-    ],
-    cmd = """
-        SCRIPTS=$$(dirname $(location third_party/slang/scripts/diagnostic_gen.py)) && \
-        $(PYTHON3) $(location third_party/slang/scripts/diagnostic_gen.py) \
-            --outDir $(@D) \
-            --srcDir $$SCRIPTS/../source \
-            --incDir $$SCRIPTS/../include/slang \
-            --diagnostics $(location third_party/slang/scripts/diagnostics.txt)
-    """,
-    toolchains = ["@rules_python//python:current_py_toolchain"],
-)
-
-genrule(
-    name = "slang_syntax_gen",
-    srcs = glob(["third_party/slang/scripts/*.txt"]) + [
-        "third_party/slang/scripts/syntax_gen.py",
-    ],
-    outs = [
-        "AllSyntax.cpp",
-        "KnownSystemName.cpp",
-        "SyntaxClone.cpp",
-        "TokenKind.cpp",
-        "slang/syntax/AllSyntax.h",
-        "slang/syntax/CSTJsonVisitorGen.h",
-        "slang/syntax/SyntaxFwd.h",
-        "slang/syntax/SyntaxKind.h",
-        "slang/parsing/TokenKind.h",
-        "slang/parsing/KnownSystemName.h",
-    ],
-    cmd = """
-        SCRIPTS=$$(dirname $(location third_party/slang/scripts/syntax_gen.py)) && \
-        $(PYTHON3) $(location third_party/slang/scripts/syntax_gen.py) \
-            --dir $(@D) \
-            --syntax $$SCRIPTS/syntax.txt
-    """,
-    toolchains = ["@rules_python//python:current_py_toolchain"],
-)
-
-# --- fmt (vendored in third_party/fmt) ---
-
-cc_library(
-    name = "fmt",
-    srcs = [
-        "third_party/fmt/src/format.cc",
-        "third_party/fmt/src/os.cc",
-    ],
-    hdrs = glob(["third_party/fmt/include/fmt/*.h"]),
-    applicable_licenses = [":license_fmt"],
-    copts = [
-        "-fPIC",
-        "-std=c++20",
-    ],
-    includes = ["third_party/fmt/include"],
-)
-
-# --- slang (vendored in third_party/slang) ---
-
-cc_library(
-    name = "slang",
-    srcs = glob(
-        ["third_party/slang/source/**/*.cpp"],
-    ) + glob(
-        ["third_party/slang/source/**/*.h"],
-    ) + [
-        ":AllSyntax.cpp",
-        ":DiagCode.cpp",
-        ":KnownSystemName.cpp",
-        ":SyntaxClone.cpp",
-        ":TokenKind.cpp",
-        ":VersionInfo.cpp",
-    ],
-    hdrs = glob([
-        "third_party/slang/include/**/*.h",
-        "third_party/slang/external/**/*.hpp",  # buildifier: disable=external-path
-        "third_party/slang/external/ieee1800/**",  # buildifier: disable=external-path
-    ]) + [
-        ":slang/diagnostics/AllDiags.h",
-        ":slang/diagnostics/AnalysisDiags.h",
-        ":slang/diagnostics/CompilationDiags.h",
-        ":slang/diagnostics/ConstEvalDiags.h",
-        ":slang/diagnostics/DeclarationsDiags.h",
-        ":slang/diagnostics/ExpressionsDiags.h",
-        ":slang/diagnostics/GeneralDiags.h",
-        ":slang/diagnostics/LexerDiags.h",
-        ":slang/diagnostics/LookupDiags.h",
-        ":slang/diagnostics/MetaDiags.h",
-        ":slang/diagnostics/NumericDiags.h",
-        ":slang/diagnostics/ParserDiags.h",
-        ":slang/diagnostics/PreprocessorDiags.h",
-        ":slang/diagnostics/StatementsDiags.h",
-        ":slang/diagnostics/SysFuncsDiags.h",
-        ":slang/diagnostics/TypesDiags.h",
-        ":slang/parsing/KnownSystemName.h",
-        ":slang/parsing/TokenKind.h",
-        ":slang/slang_export.h",
-        ":slang/syntax/AllSyntax.h",
-        ":slang/syntax/CSTJsonVisitorGen.h",
-        ":slang/syntax/SyntaxFwd.h",
-        ":slang/syntax/SyntaxKind.h",
-    ],
-    applicable_licenses = [":license_slang"],
-    copts = [
-        "-fPIC",
-        "-std=c++20",
-        "-Wno-unused-parameter",
-    ],
-    defines = ["SLANG_BOOST_SINGLE_HEADER"],
-    includes = [
-        "third_party/slang/external",
-        "third_party/slang/include",
-        "third_party/slang/source/ast/builtins",
-    ],
-    deps = [":fmt"],
-)
 
 expand_template(
     name = "version_h",
@@ -250,9 +57,8 @@ cc_library(
     ],
     visibility = ["//src/yosys_plugin:__pkg__"],
     deps = [
-        ":slang",
+        "@vendored-slang//:slang",
         "@yosys//:hdrs",
     ],
     alwayslink = True,
 )
-

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,3 +12,7 @@ bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(name = "rules_python", version = "2.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "fmt", version = "12.1.0")
+
+slang_ext = use_extension("//:dependency_support/slang_ext.bzl", "vendored_slang_extension")
+use_repo(slang_ext, "vendored-slang")

--- a/dependency_support/slang.BUILD
+++ b/dependency_support/slang.BUILD
@@ -1,0 +1,172 @@
+# The diagnostic_gen.py / syntax_gen.py codegen mirrors what slang's own
+# cmake runs at build time. SLANG_VERSION_PATCH/HASH are stubbed (cmake
+# derives them from `git describe`); refine with a workspace-status hook
+# if needed.
+
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_license//rules:license.bzl", "license")
+load(
+    "@yosys-slang//:dependency_support/slang_ext.bzl",
+    "SLANG_VERSION_HASH",
+    "SLANG_VERSION_MAJOR",
+    "SLANG_VERSION_MINOR",
+    "SLANG_VERSION_PATCH",
+)
+
+package(
+    features = ["layering_check"],
+)
+
+license(
+    name = "license_slang",
+    package_name = "slang",
+    license_kinds = ["@rules_license//licenses/spdx:MIT"],
+    license_text = "LICENSE",
+)
+
+genrule(
+    name = "slang_export_h",
+    outs = ["slang/slang_export.h"],
+    cmd = """cat > $@ << 'HEADER'
+#pragma once
+#define SLANG_EXPORT
+#define SLANG_NO_EXPORT
+HEADER""",
+)
+
+expand_template(
+    name = "slang_version_cpp",
+    out = "VersionInfo.cpp",
+    substitutions = {
+        "@SLANG_VERSION_MAJOR@": str(SLANG_VERSION_MAJOR),
+        "@SLANG_VERSION_MINOR@": str(SLANG_VERSION_MINOR),
+        "@SLANG_VERSION_PATCH@": str(SLANG_VERSION_PATCH),
+        "@SLANG_VERSION_HASH@": SLANG_VERSION_HASH,
+    },
+    template = "source/util/VersionInfo.cpp.in",
+)
+
+genrule(
+    name = "slang_diag_gen",
+    srcs = [
+        "scripts/diagnostic_gen.py",
+        "scripts/diagnostics.txt",
+    ] + glob([
+        "source/**/*.cpp",
+        "include/slang/**/*.h",
+    ]),
+    outs = [
+        "DiagCode.cpp",
+        "slang/diagnostics/AllDiags.h",
+        "slang/diagnostics/AnalysisDiags.h",
+        "slang/diagnostics/CompilationDiags.h",
+        "slang/diagnostics/ConstEvalDiags.h",
+        "slang/diagnostics/DeclarationsDiags.h",
+        "slang/diagnostics/ExpressionsDiags.h",
+        "slang/diagnostics/GeneralDiags.h",
+        "slang/diagnostics/LexerDiags.h",
+        "slang/diagnostics/LookupDiags.h",
+        "slang/diagnostics/MetaDiags.h",
+        "slang/diagnostics/NumericDiags.h",
+        "slang/diagnostics/ParserDiags.h",
+        "slang/diagnostics/PreprocessorDiags.h",
+        "slang/diagnostics/StatementsDiags.h",
+        "slang/diagnostics/SysFuncsDiags.h",
+        "slang/diagnostics/TypesDiags.h",
+    ],
+    cmd = """
+        SCRIPTS=$$(dirname $(location scripts/diagnostic_gen.py)) && \
+        $(PYTHON3) $(location scripts/diagnostic_gen.py) \
+            --outDir $(@D) \
+            --srcDir $$SCRIPTS/../source \
+            --incDir $$SCRIPTS/../include/slang \
+            --diagnostics $(location scripts/diagnostics.txt)
+    """,
+    toolchains = ["@rules_python//python:current_py_toolchain"],
+)
+
+genrule(
+    name = "slang_syntax_gen",
+    srcs = glob(["scripts/*.txt"]) + [
+        "scripts/syntax_gen.py",
+    ],
+    outs = [
+        "AllSyntax.cpp",
+        "KnownSystemName.cpp",
+        "SyntaxClone.cpp",
+        "TokenKind.cpp",
+        "slang/syntax/AllSyntax.h",
+        "slang/syntax/CSTJsonVisitorGen.h",
+        "slang/syntax/SyntaxFwd.h",
+        "slang/syntax/SyntaxKind.h",
+        "slang/parsing/TokenKind.h",
+        "slang/parsing/KnownSystemName.h",
+    ],
+    cmd = """
+        SCRIPTS=$$(dirname $(location scripts/syntax_gen.py)) && \
+        $(PYTHON3) $(location scripts/syntax_gen.py) \
+            --dir $(@D) \
+            --syntax $$SCRIPTS/syntax.txt
+    """,
+    toolchains = ["@rules_python//python:current_py_toolchain"],
+)
+
+cc_library(
+    name = "slang",
+    srcs = glob(
+        ["source/**/*.cpp"],
+    ) + glob(
+        ["source/**/*.h"],
+    ) + [
+        ":AllSyntax.cpp",
+        ":DiagCode.cpp",
+        ":KnownSystemName.cpp",
+        ":SyntaxClone.cpp",
+        ":TokenKind.cpp",
+        ":VersionInfo.cpp",
+    ],
+    hdrs = glob([
+        "include/**/*.h",
+        "external/**/*.hpp",  # buildifier: disable=external-path
+        "external/ieee1800/**",  # buildifier: disable=external-path
+    ]) + [
+        ":slang/diagnostics/AllDiags.h",
+        ":slang/diagnostics/AnalysisDiags.h",
+        ":slang/diagnostics/CompilationDiags.h",
+        ":slang/diagnostics/ConstEvalDiags.h",
+        ":slang/diagnostics/DeclarationsDiags.h",
+        ":slang/diagnostics/ExpressionsDiags.h",
+        ":slang/diagnostics/GeneralDiags.h",
+        ":slang/diagnostics/LexerDiags.h",
+        ":slang/diagnostics/LookupDiags.h",
+        ":slang/diagnostics/MetaDiags.h",
+        ":slang/diagnostics/NumericDiags.h",
+        ":slang/diagnostics/ParserDiags.h",
+        ":slang/diagnostics/PreprocessorDiags.h",
+        ":slang/diagnostics/StatementsDiags.h",
+        ":slang/diagnostics/SysFuncsDiags.h",
+        ":slang/diagnostics/TypesDiags.h",
+        ":slang/parsing/KnownSystemName.h",
+        ":slang/parsing/TokenKind.h",
+        ":slang/slang_export.h",
+        ":slang/syntax/AllSyntax.h",
+        ":slang/syntax/CSTJsonVisitorGen.h",
+        ":slang/syntax/SyntaxFwd.h",
+        ":slang/syntax/SyntaxKind.h",
+    ],
+    applicable_licenses = [":license_slang"],
+    copts = [
+        "-fPIC",
+        "-std=c++20",
+        "-Wno-unused-parameter",
+    ],
+    defines = ["SLANG_BOOST_SINGLE_HEADER"],
+    includes = [
+        "external",
+        "include",
+        "source/ast/builtins",
+    ],
+    visibility = ["@yosys-slang//:__subpackages__"],
+    deps = ["@fmt"],
+)

--- a/dependency_support/slang_ext.bzl
+++ b/dependency_support/slang_ext.bzl
@@ -1,0 +1,23 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+# Version of the slang library tracked in third_party/slang for the
+# regular build. In BAZEL, we don't have to use the submodule but
+# can refer to the hash here directly.
+# Bump when the submodule is updated. SLANG_VERSION_PATCH/HASH are
+# normally derived from `git describe`
+SLANG_VERSION_MAJOR = 10
+SLANG_VERSION_MINOR = 0
+SLANG_VERSION_PATCH = 0
+SLANG_VERSION_HASH = "f04e81565793c768b747a8fd058f3e7aeceee1b5"
+
+def _vendored_slang_extension_impl(ctx):
+    git_repository(
+        name = "vendored-slang",
+        remote = "https://github.com/MikePopoloski/slang.git",
+        commit = SLANG_VERSION_HASH,
+        build_file = Label("//:dependency_support/slang.BUILD"),
+    )
+
+vendored_slang_extension = module_extension(
+    implementation = _vendored_slang_extension_impl,
+)


### PR DESCRIPTION
Break out the build rules into its own BUILD file, and load the sources via a MODULE.bazel extension. Put all variables w.r.t. SLANG_VERSION into one place, so it is easy to update as needed.

Also instead of third_party/ fmt library, use that from BCR.

Now, we don't need any submodules anymore in the bazel build.

This should bring yosys-slang close to be ready to be added to the bazel central registry.