### PR TITLE
IWYU: Fix missing includes for symbols used in files.

### DIFF
--- a/src/abort_helpers.cc
+++ b/src/abort_helpers.cc
@@ -4,6 +4,7 @@
 // Copyright Martin Povišer <povik@cutebit.org>
 // Distributed under the terms of the ISC license, see LICENSE
 //
+#include "kernel/log.h"
 #include "slang/ast/Compilation.h"
 #include "slang/ast/Expression.h"
 #include "slang/ast/Statement.h"
@@ -13,7 +14,11 @@
 #include "slang/ast/symbols/ParameterSymbols.h"
 #include "slang/ast/types/Type.h"
 #include "slang/text/Json.h"
+#include "slang/text/SourceLocation.h"
 #include "slang/text/SourceManager.h"
+#include <iostream>
+#include <string>
+#include <string_view>
 
 #include "slang_frontend.h"
 

--- a/src/addressing.cc
+++ b/src/addressing.cc
@@ -4,8 +4,12 @@
 // Copyright Martin Povišer <povik@cutebit.org>
 // Distributed under the terms of the ISC license, see LICENSE
 //
+#include "kernel/log.h"
+#include "kernel/rtlil.h"
+#include "slang/ast/Expression.h"
 #include "slang/ast/expressions/SelectExpressions.h"
 #include "slang/ast/types/Type.h"
+#include <cstdint>
 
 // Fix for Yosys declaring ceil_log2 as both inline and non-inline
 // but not defining the non-inline one; be sure to include utils.h

--- a/src/async_pattern.cc
+++ b/src/async_pattern.cc
@@ -4,21 +4,27 @@
 // Copyright Martin Povišer <povik@cutebit.org>
 // Distributed under the terms of the ISC license, see LICENSE
 //
+#include "kernel/log.h"
 #include "slang/ast/Expression.h"
+#include "slang/ast/SemanticFacts.h"
+#include "slang/ast/Statement.h"
 #include "slang/ast/TimingControl.h"
 #include "slang/ast/expressions/AssignmentExpressions.h"
 #include "slang/ast/expressions/ConversionExpression.h"
 #include "slang/ast/expressions/MiscExpressions.h"
+#include "slang/ast/expressions/Operator.h"
 #include "slang/ast/expressions/OperatorExpressions.h"
 #include "slang/ast/expressions/SelectExpressions.h"
 #include "slang/ast/statements/ConditionalStatements.h"
 #include "slang/ast/statements/MiscStatements.h"
 #include "slang/ast/symbols/BlockSymbols.h"
 #include "slang/ast/types/Type.h"
+#include <cstddef>
 
 #include "async_pattern.h"
 #include "diag.h"
 #include "slang/syntax/AllSyntax.h"
+#include "variables.h"
 
 namespace slang_frontend {
 

--- a/src/blackboxes.cc
+++ b/src/blackboxes.cc
@@ -6,15 +6,26 @@
 //
 #include "slang/ast/ASTVisitor.h"
 #include "slang/ast/Compilation.h"
+#include "slang/ast/SemanticFacts.h"
 #include "slang/ast/symbols/CompilationUnitSymbols.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
+#include "slang/ast/symbols/ParameterSymbols.h"
+#include "slang/ast/types/DeclaredType.h"
+#include "slang/parsing/Token.h"
+#include "slang/parsing/TokenKind.h"
 #include "slang/syntax/AllSyntax.h"
+#include "slang/syntax/SyntaxKind.h"
+#include "slang/syntax/SyntaxNode.h"
 #include "slang/syntax/SyntaxPrinter.h"
 #include "slang/syntax/SyntaxTree.h"
+#include <memory>
+#include <string>
 
 #include "kernel/rtlil.h"
 
 #include "diag.h"
+#include "slang/util/BumpAllocator.h"
+#include "slang/util/SmallVector.h"
 #include "slang_frontend.h"
 
 namespace slang_frontend {

--- a/src/builder.cc
+++ b/src/builder.cc
@@ -4,8 +4,15 @@
 // Copyright Martin Povišer <povik@cutebit.org>
 // Distributed under the terms of the ISC license, see LICENSE
 //
+#include <cstddef>
+#include <cstdint>
 #include <limits>
+#include <string>
+#include <string_view>
+#include <utility>
 
+#include "kernel/log.h"
+#include "kernel/rtlil.h"
 #include "slang_frontend.h"
 #include "variables.h"
 

--- a/src/cases.h
+++ b/src/cases.h
@@ -6,9 +6,11 @@
 //
 #pragma once
 
+#include "kernel/rtlil.h"
 #include "slang/ast/symbols/ValueSymbol.h"
 
 #include "diag.h"
+#include "slang/text/SourceLocation.h"
 #include "slang_frontend.h"
 #include "variables.h"
 

--- a/src/diag.cc
+++ b/src/diag.cc
@@ -5,6 +5,8 @@
 // Distributed under the terms of the ISC license, see LICENSE
 //
 #include "diag.h"
+#include "slang/diagnostics/Diagnostics.h"
+#include "slang/text/SourceLocation.h"
 #include "slang_frontend.h"
 
 namespace slang_frontend {

--- a/src/initialization.cc
+++ b/src/initialization.cc
@@ -4,8 +4,14 @@
 // Copyright Martin Povišer <povik@cutebit.org>
 // Distributed under the terms of the ISC license, see LICENSE
 //
+#include "kernel/log.h"
+#include "kernel/rtlil.h"
 #include "slang/ast/ASTVisitor.h"
+#include "slang/ast/SemanticFacts.h"
+#include "slang/ast/symbols/BlockSymbols.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
+#include "slang/ast/symbols/MemberSymbols.h"
+#include "slang/ast/symbols/ValueSymbol.h"
 #include "slang/ast/symbols/VariableSymbols.h"
 #include "slang/ast/types/Type.h"
 

--- a/src/lvalue.cc
+++ b/src/lvalue.cc
@@ -4,13 +4,20 @@
 // Copyright Martin Povišer <povik@cutebit.org>
 // Distributed under the terms of the ISC license, see LICENSE
 //
+#include "kernel/log.h"
+#include "kernel/rtlil.h"
+#include "slang/ast/Expression.h"
+#include "slang/ast/Symbol.h"
 #include "slang/ast/expressions/ConversionExpression.h"
 #include "slang/ast/expressions/MiscExpressions.h"
 #include "slang/ast/expressions/OperatorExpressions.h"
 #include "slang/ast/expressions/SelectExpressions.h"
 #include "slang/ast/symbols/MemberSymbols.h"
+#include "slang/ast/symbols/ValueSymbol.h"
 #include "slang/ast/symbols/VariableSymbols.h"
 #include "slang/ast/types/Type.h"
+#include <cstdint>
+#include <optional>
 
 #include "diag.h"
 #include "slang_frontend.h"

--- a/src/memory.h
+++ b/src/memory.h
@@ -5,14 +5,24 @@
 // Distributed under the terms of the ISC license, see LICENSE
 //
 #pragma once
+#include <functional>
 #include <optional>
 #include <string>
 #include <string_view>
 
 #include "async_pattern.h"
 #include "diag.h"
+#include "kernel/log.h"
 #include "slang/ast/ASTVisitor.h"
 #include "slang/ast/Compilation.h"
+#include "slang/ast/Expression.h"
+#include "slang/ast/expressions/MiscExpressions.h"
+#include "slang/ast/expressions/SelectExpressions.h"
+#include "slang/ast/statements/MiscStatements.h"
+#include "slang/ast/symbols/BlockSymbols.h"
+#include "slang/ast/symbols/PortSymbols.h"
+#include "slang/ast/symbols/VariableSymbols.h"
+#include "slang/text/SourceLocation.h"
 #include "slang_frontend.h"
 
 extern slang::ast::Compilation *global_compilation;

--- a/src/naming.cc
+++ b/src/naming.cc
@@ -4,8 +4,12 @@
 // Copyright Martin Povišer <povik@cutebit.org>
 // Distributed under the terms of the ISC license, see LICENSE
 //
+#include "kernel/log.h"
+#include "slang/ast/Scope.h"
 #include "slang/ast/symbols/VariableSymbols.h"
 #include "slang/ast/types/Type.h"
+#include <cstdint>
+#include <string>
 
 #include "slang_frontend.h"
 #include "variables.h"

--- a/src/procedural.cc
+++ b/src/procedural.cc
@@ -5,6 +5,9 @@
 // Distributed under the terms of the ISC license, see LICENSE
 //
 
+#include "kernel/log.h"
+#include "slang/ast/Expression.h"
+#include "slang/ast/Scope.h"
 #include "slang/ast/Statement.h"
 #include "slang/ast/expressions/AssignmentExpressions.h"
 #include "slang/ast/expressions/ConversionExpression.h"
@@ -14,6 +17,8 @@
 #include "slang/ast/symbols/SubroutineSymbols.h"
 #include "slang/ast/symbols/VariableSymbols.h"
 #include "slang/ast/types/Type.h"
+#include <cstdint>
+#include <string>
 
 // Fix for Yosys declaring ceil_log2 as both inline and non-inline
 // but not defining the non-inline one; be sure to include utils.h
@@ -23,6 +28,7 @@
 
 #include "cases.h"
 #include "diag.h"
+#include "slang/text/SourceLocation.h"
 #include "slang_frontend.h"
 #include "variables.h"
 

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -5,22 +5,66 @@
 // Distributed under the terms of the ISC license, see LICENSE
 //
 // clang-format off
+#include <string.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cassert>
+#include <fstream>
+#include <limits>
+#include <sstream>
+#include <exception>
+#include <cmath>
+#include <iostream>
+#include <cstdint>
+#include <string_view>
+#include <string>
+#include <cstddef>
+#include <utility>
+#include <filesystem>
+#include <optional>
 #include <vector>
 
 #include "slang/ast/ASTVisitor.h"
+#include "kernel/yosys_common.h"
+#include "kernel/log.h"
 #include "slang/ast/Compilation.h"
 #include "slang/ast/EvalContext.h"
+#include "slang/ast/Expression.h"
 #include "slang/ast/SemanticFacts.h"
+#include "slang/ast/Statement.h"
+#include "slang/ast/Symbol.h"
 #include "slang/ast/SystemSubroutine.h"
+#include "slang/ast/expressions/AssertionExpr.h"
+#include "slang/ast/expressions/AssignmentExpressions.h"
+#include "slang/ast/expressions/CallExpression.h"
+#include "slang/ast/expressions/LiteralExpressions.h"
+#include "slang/ast/expressions/MiscExpressions.h"
+#include "slang/ast/expressions/Operator.h"
+#include "slang/ast/expressions/OperatorExpressions.h"
+#include "slang/ast/expressions/SelectExpressions.h"
+#include "slang/ast/statements/MiscStatements.h"
+#include "slang/ast/symbols/BlockSymbols.h"
+#include "slang/ast/symbols/CheckerSymbols.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
+#include "slang/ast/symbols/MemberSymbols.h"
+#include "slang/ast/symbols/ParameterSymbols.h"
+#include "slang/ast/symbols/SpecifySymbols.h"
+#include "slang/ast/symbols/VariableSymbols.h"
+#include "slang/ast/types/AllTypes.h"
 #include "slang/diagnostics/CompilationDiags.h"
 #include "slang/diagnostics/DiagnosticEngine.h"
+#include "slang/diagnostics/Diagnostics.h"
 #include "slang/diagnostics/LookupDiags.h"
 #include "slang/driver/Driver.h"
+#include "slang/numeric/ConstantValue.h"
+#include "slang/numeric/SVInt.h"
+#include "slang/syntax/SyntaxKind.h"
 #include "slang/syntax/SyntaxPrinter.h"
 #include "slang/syntax/SyntaxTree.h"
 #include "slang/syntax/AllSyntax.h"
 #include "slang/text/Json.h"
+#include "slang/text/SourceLocation.h"
+#include "slang/util/SmallVector.h"
 #include "slang/util/Util.h"
 
 #include "kernel/bitpattern.h"

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -6,7 +6,23 @@
 //
 // clang-format off
 #pragma once
+#include <variant>
+#include <tuple>
+#include <cstdint>
+#include <string_view>
+#include <string>
+#include <utility>
+#include <optional>
+#include "kernel/log.h"
+#include "kernel/yosys_common.h"
 #include "slang/ast/EvalContext.h"
+#include "slang/ast/Scope.h"
+#include "slang/ast/SemanticFacts.h"
+#include "slang/ast/symbols/CompilationUnitSymbols.h"
+#include "slang/diagnostics/Diagnostics.h"
+#include "slang/numeric/ConstantValue.h"
+#include "slang/text/SourceLocation.h"
+#include "slang/util/Enum.h"
 #include "kernel/rtlil.h"
 
 // work around yosys PR #4524 changing the way you ask for pointer hashing

--- a/src/statements.h
+++ b/src/statements.h
@@ -6,10 +6,26 @@
 //
 #pragma once
 
+#include "diag.h"
+#include "kernel/log.h"
 #include "kernel/rtlil.h"
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
 
 #include "cases.h"
 #include "slang/ast/ASTVisitor.h"
+#include "slang/ast/SemanticFacts.h"
+#include "slang/ast/Statement.h"
+#include "slang/ast/expressions/CallExpression.h"
+#include "slang/ast/statements/ConditionalStatements.h"
+#include "slang/ast/statements/LoopStatements.h"
+#include "slang/ast/statements/MiscStatements.h"
+#include "slang/ast/symbols/ValueSymbol.h"
+#include "slang/ast/symbols/VariableSymbols.h"
+#include "slang/text/SourceLocation.h"
 #include "slang_frontend.h"
 #include "variables.h"
 

--- a/src/sva.cc
+++ b/src/sva.cc
@@ -5,9 +5,14 @@
 // Distributed under the terms of the ISC license, see LICENSE
 //
 // clang-format off
+#include <string>
+#include <optional>
 #include "slang/ast/statements/MiscStatements.h"
+#include "slang/ast/SemanticFacts.h"
+#include "kernel/rtlil.h"
 #include "slang/ast/expressions/AssertionExpr.h"
 #include "slang/ast/symbols/BlockSymbols.h"
+#include "slang/text/SourceLocation.h"
 #include "slang/util/ScopeGuard.h"
 
 #include "slang_frontend.h"

--- a/src/variables.cc
+++ b/src/variables.cc
@@ -4,12 +4,19 @@
 // Copyright Martin Povišer <povik@cutebit.org>
 // Distributed under the terms of the ISC license, see LICENSE
 //
+#include "kernel/log.h"
+#include "slang/ast/Scope.h"
+#include "slang/ast/SemanticFacts.h"
+#include "slang/ast/Symbol.h"
 #include "slang/ast/symbols/BlockSymbols.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
 #include "slang/ast/symbols/ValueSymbol.h"
 #include "slang/ast/symbols/VariableSymbols.h"
 #include "slang/ast/types/NetType.h"
 #include "slang/ast/types/Type.h"
+#include <cstddef>
+#include <cstdint>
+#include <string>
 
 #include "slang_frontend.h"
 #include "variables.h"

--- a/src/variables.h
+++ b/src/variables.h
@@ -5,8 +5,15 @@
 // Distributed under the terms of the ISC license, see LICENSE
 //
 #pragma once
+#include "kernel/log.h"
 #include "slang_frontend.h"
 #include <cinttypes>
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
+#include <iterator>
+#include <string>
+#include <tuple>
 
 namespace slang_frontend {
 


### PR DESCRIPTION
Found with `clang-tidy` (diagnostic `misc-include-cleaner`).

With some scripts, applied the necessary includes.

Breakdown

```
src/lvalue.cc:                           #include <optional> for std::nullopt
src/statements.h:                        #include <optional> for std::nullopt
src/slang_frontend.cc:                   #include <optional> for std::optional
src/slang_frontend.h:                    #include <optional> for std::optional
src/sva.cc:                              #include <optional> for std::optional
src/slang_frontend.cc:                   #include <filesystem> for std::filesystem.*
src/async_pattern.cc:                    #include "kernel/log.h" for log_abort
src/lvalue.cc:                           #include "kernel/log.h" for log_abort
src/memory.h:                            #include "kernel/log.h" for log_abort
src/procedural.cc:                       #include "kernel/log.h" for log_abort
src/slang_frontend.cc:                   #include "kernel/log.h" for log_abort
src/variables.cc:                        #include "kernel/log.h" for log_abort
src/abort_helpers.cc:                    #include "kernel/log.h" for log_assert
src/addressing.cc:                       #include "kernel/log.h" for log_assert
src/builder.cc:                          #include "kernel/log.h" for log_assert
src/initialization.cc:                   #include "kernel/log.h" for log_assert
src/naming.cc:                           #include "kernel/log.h" for log_assert
src/statements.h:                        #include "kernel/log.h" for log_assert
src/variables.h:                         #include "kernel/log.h" for log_assert
src/slang_frontend.h:                    #include "kernel/log.h" for Yosys::ys_debug
src/lvalue.cc:                           #include "slang/ast/Expression.h" for slang::ast::ExpressionKind
src/memory.h:                            #include "slang/ast/Expression.h" for slang::ast::ExpressionKind
src/procedural.cc:                       #include "slang/ast/Expression.h" for slang::ast::ExpressionKind
src/slang_frontend.cc:                   #include "slang/ast/Expression.h" for slang::ast::ExpressionKind
src/initialization.cc:                   #include "slang/ast/symbols/ValueSymbol.h" for slang::ast::ValueSymbol
src/lvalue.cc:                           #include "slang/ast/symbols/ValueSymbol.h" for slang::ast::ValueSymbol
src/statements.h:                        #include "slang/ast/symbols/ValueSymbol.h" for slang::ast::ValueSymbol
src/diag.cc:                             #include "slang/diagnostics/Diagnostics.h" for slang::Diagnostics?
src/slang_frontend.cc:                   #include "slang/diagnostics/Diagnostics.h" for slang::Diagnostics?
src/slang_frontend.h:                    #include "slang/diagnostics/Diagnostics.h" for slang::Diagnostics?
src/cases.h:                             #include "slang/text/SourceLocation.h" for slang::SourceLocation
src/diag.cc:                             #include "slang/text/SourceLocation.h" for slang::SourceLocation
src/memory.h:                            #include "slang/text/SourceLocation.h" for slang::SourceLocation
src/procedural.cc:                       #include "slang/text/SourceLocation.h" for slang::SourceLocation
src/slang_frontend.h:                    #include "slang/text/SourceLocation.h" for slang::SourceLocation
src/statements.h:                        #include "slang/text/SourceLocation.h" for slang::SourceLocation
src/abort_helpers.cc:                    #include "slang/text/SourceLocation.h" for slang::SourceRange
src/slang_frontend.cc:                   #include "slang/text/SourceLocation.h" for slang::SourceRange
src/sva.cc:                              #include "slang/text/SourceLocation.h" for slang::SourceRange
src/builder.cc:                          #include <utility> for std::pair
src/slang_frontend.cc:                   #include <utility> for std::pair
src/slang_frontend.h:                    #include <utility> for std::pair
src/async_pattern.cc:                    #include <cstddef> for (std::)?size_t
src/builder.cc:                          #include <cstddef> for (std::)?size_t
src/slang_frontend.cc:                   #include <cstddef> for (std::)?size_t
src/statements.h:                        #include <cstddef> for (std::)?size_t
src/variables.cc:                        #include <cstddef> for (std::)?size_t
src/variables.h:                         #include <cstddef> for (std::)?size_t
src/abort_helpers.cc:                    #include <string> for std::string
src/blackboxes.cc:                       #include <string> for std::string
src/builder.cc:                          #include <string> for std::string
src/naming.cc:                           #include <string> for std::string
src/procedural.cc:                       #include <string> for std::string
src/slang_frontend.cc:                   #include <string> for std::string
src/slang_frontend.h:                    #include <string> for std::string
src/statements.h:                        #include <string> for std::string
src/sva.cc:                              #include <string> for std::string
src/variables.cc:                        #include <string> for std::string
src/variables.h:                         #include <string> for std::string
src/abort_helpers.cc:                    #include <string_view> for std::string_view
src/builder.cc:                          #include <string_view> for std::string_view
src/slang_frontend.cc:                   #include <string_view> for std::string_view
src/slang_frontend.h:                    #include <string_view> for std::string_view
src/addressing.cc:                       #include <cstdint> for (std::)?u?int[123468]*_t
src/builder.cc:                          #include <cstdint> for (std::)?u?int[123468]*_t
src/lvalue.cc:                           #include <cstdint> for (std::)?u?int[123468]*_t
src/naming.cc:                           #include <cstdint> for (std::)?u?int[123468]*_t
src/procedural.cc:                       #include <cstdint> for (std::)?u?int[123468]*_t
src/slang_frontend.cc:                   #include <cstdint> for (std::)?u?int[123468]*_t
src/slang_frontend.h:                    #include <cstdint> for (std::)?u?int[123468]*_t
src/statements.h:                        #include <cstdint> for (std::)?u?int[123468]*_t
src/variables.cc:                        #include <cstdint> for (std::)?u?int[123468]*_t
src/variables.h:                         #include <cstdint> for (std::)?u?int[123468]*_t
src/addressing.cc:                       #include "kernel/rtlil.h" for Yosys::RTLIL::SigSpec
src/builder.cc:                          #include "kernel/rtlil.h" for Yosys::RTLIL::SigSpec
src/cases.h:                             #include "kernel/rtlil.h" for Yosys::RTLIL::SigSpec
src/initialization.cc:                   #include "kernel/rtlil.h" for Yosys::RTLIL::SigSpec
src/lvalue.cc:                           #include "kernel/rtlil.h" for Yosys::RTLIL::SigSpec
src/sva.cc:                              #include "kernel/rtlil.h" for Yosys::RTLIL::SigSpec
src/naming.cc:                           #include "slang/ast/Scope.h" for slang::ast::Scope
src/procedural.cc:                       #include "slang/ast/Scope.h" for slang::ast::Scope
src/slang_frontend.h:                    #include "slang/ast/Scope.h" for slang::ast::Scope
src/variables.cc:                        #include "slang/ast/Scope.h" for slang::ast::Scope
src/async_pattern.cc:                    #include "slang/ast/Statement.h" for slang::ast::StatementKind
src/slang_frontend.cc:                   #include "slang/ast/Statement.h" for slang::ast::StatementKind
src/statements.h:                        #include "slang/ast/Statement.h" for slang::ast::StatementKind
src/memory.h:                            #include "slang/ast/symbols/VariableSymbols.h" for slang::ast::VariableSymbol
src/slang_frontend.cc:                   #include "slang/ast/symbols/VariableSymbols.h" for slang::ast::VariableSymbol
src/statements.h:                        #include "slang/ast/symbols/VariableSymbols.h" for slang::ast::VariableSymbol
src/initialization.cc:                   #include "slang/ast/SemanticFacts.h" for slang::ast::VariableLifetime
src/statements.h:                        #include "slang/ast/SemanticFacts.h" for slang::ast::VariableLifetime
src/variables.cc:                        #include "slang/ast/SemanticFacts.h" for slang::ast::VariableLifetime
src/blackboxes.cc:                       #include "slang/ast/SemanticFacts.h" for slang::ast::ArgumentDirection
src/async_pattern.cc:                    #include "slang/ast/SemanticFacts.h" for slang::ast::ProceduralBlockKind
src/slang_frontend.h:                    #include "slang/ast/SemanticFacts.h" for slang::ast::TimingControl
src/sva.cc:                              #include "slang/ast/SemanticFacts.h" for slang::ast::AssertionKind
src/initialization.cc:                   #include "slang/ast/symbols/BlockSymbols.h" for slang::ast::GenerateBlockSymbol
src/memory.h:                            #include "slang/ast/symbols/BlockSymbols.h" for slang::ast::GenerateBlockSymbol
src/slang_frontend.cc:                   #include "slang/ast/symbols/BlockSymbols.h" for slang::ast::GenerateBlockSymbol
src/memory.h:                            #include "slang/ast/statements/MiscStatements.h" for slang::ast::ExpressionStatement
src/slang_frontend.cc:                   #include "slang/ast/statements/MiscStatements.h" for slang::ast::ExpressionStatement
src/statements.h:                        #include "slang/ast/statements/MiscStatements.h" for slang::ast::ExpressionStatement
src/memory.h:                            #include "slang/ast/expressions/MiscExpressions.h" for slang::ast::ValueExpressionBase
src/slang_frontend.cc:                   #include "slang/ast/expressions/MiscExpressions.h" for slang::ast::ValueExpressionBase
src/memory.h:                            #include <functional> for std::function
src/statements.h:                        #include <functional> for std::function
src/abort_helpers.cc:                    #include <iostream> for std::cout
src/slang_frontend.cc:                   #include <iostream> for std::cout
src/slang_frontend.h:                    #include <tuple> for std::tuple
src/variables.h:                         #include <tuple> for std::tuple
src/blackboxes.cc:                       #include "slang/util/SmallVector.h" for slang::SmallVector
src/slang_frontend.cc:                   #include "slang/util/SmallVector.h" for slang::SmallVector
src/slang_frontend.h:                    #include <variant> for std::variant
src/blackboxes.cc:                       #include <memory> for std::shared_ptr
src/slang_frontend.cc:                   #include <cmath> for std::abs
src/slang_frontend.cc:                   #include <exception> for std::exception
src/slang_frontend.cc:                   #include "slang/ast/expressions/OperatorExpressions.h" for slang::ast::ConditionalExpression
src/slang_frontend.cc:                   #include "slang/ast/Symbol.h" for slang::ast::PackedArrayType
src/slang_frontend.cc:                   #include "slang/ast/expressions/LiteralExpressions.h" for slang::ast::IntegerLiteral
src/slang_frontend.cc:                   #include "slang/ast/symbols/MemberSymbols.h" for slang::ast::PropertySymbol
src/initialization.cc:                   #include "slang/ast/symbols/MemberSymbols.h" for slang::ast::ModportPortSymbol
src/slang_frontend.cc:                   #include <sstream> for std::ostringstream
src/slang_frontend.cc:                   #include <limits> for std::numeric_limits
src/variables.h:                         #include <initializer_list> for std::initializer_list
src/slang_frontend.cc:                   #include "slang/numeric/ConstantValue.h" for slang::ConstantValue
src/slang_frontend.h:                    #include "slang/numeric/ConstantValue.h" for slang::ConstantValue
src/blackboxes.cc:                       #include "slang/syntax/SyntaxKind.h" for slang::syntax::SyntaxKind
src/slang_frontend.cc:                   #include "slang/syntax/SyntaxKind.h" for slang::syntax::SyntaxKind
src/async_pattern.cc:                    #include "slang/ast/expressions/Operator.h" for slang::ast::UnaryOperator
src/slang_frontend.cc:                   #include "slang/ast/expressions/Operator.h" for slang::ast::UnaryOperator
src/blackboxes.cc:                       #include "slang/ast/symbols/ParameterSymbols.h" for slang::ast::ParameterSymbol
src/slang_frontend.cc:                   #include "slang/ast/symbols/ParameterSymbols.h" for slang::ast::ParameterSymbol
src/slang_frontend.cc:                   #include "kernel/yosys_common.h" for Yosys::Cell
src/slang_frontend.h:                    #include "kernel/yosys_common.h" for Yosys::Cell
src/slang_frontend.cc:                   #include "slang/ast/expressions/CallExpression.h" for slang::ast::CallExpression
src/statements.h:                        #include "slang/ast/expressions/CallExpression.h" for slang::ast::CallExpression
src/memory.h:                            #include "slang/ast/expressions/SelectExpressions.h" for slang::ast::MemberAccessExpression
src/slang_frontend.cc:                   #include "slang/ast/expressions/SelectExpressions.h" for slang::ast::MemberAccessExpression
src/statements.h:                        #include "slang/ast/statements/LoopStatements.h" for slang::ast::ForLoopStatement
src/memory.h:                            #include "slang/ast/symbols/PortSymbols.h" for slang::ast::PortSymbol
src/slang_frontend.cc:                   #include <fstream> for std::ifstream
src/statements.h:                        #include "diag.h" for slang_frontend::diag.*
src/slang_frontend.cc:                   #include <cassert> for assert
src/variables.h:                         #include <iterator> for std::input_iterator_tag
src/blackboxes.cc:                       #include "slang/parsing/Token.h" for slang::parsing::Trivia
src/statements.h:                        #include "slang/ast/statements/ConditionalStatements.h" for slang::ast::CaseStatement
src/lvalue.cc:                           #include "slang/ast/Symbol.h" for slang::ast::SymbolKind
src/variables.cc:                        #include "slang/ast/Symbol.h" for slang::ast::SymbolKind
src/blackboxes.cc:                       #include "slang/parsing/TokenKind.h" for slang::parsing::TokenKind
src/slang_frontend.cc:                   #include "slang/ast/expressions/AssertionExpr.h" for slang::ast::SimpleAssertionExpr
src/blackboxes.cc:                       #include "slang/ast/types/DeclaredType.h" for slang::ast::DeclaredType
src/blackboxes.cc:                       #include "slang/util/BumpAllocator.h" for slang::BumpAllocator
src/addressing.cc:                       #include "slang/ast/Expression.h" for slang::ast::RangeSelectionKind
src/slang_frontend.h:                    #include "slang/util/Enum.h" for SLANG_ENUM
src/slang_frontend.cc:                   #include <cstdio> for fgets
src/async_pattern.cc:                    #include "variables.h" for slang_frontend::VariableBits
src/blackboxes.cc:                       #include "slang/syntax/SyntaxNode.h" for slang::syntax::SyntaxList
src/slang_frontend.cc:                   #include "slang/numeric/SVInt.h" for slang::LiteralBase
src/slang_frontend.cc:                   #include "slang/ast/symbols/SpecifySymbols.h" for slang::ast::SpecifyBlockSymbol
src/slang_frontend.h:                    #include "slang/ast/symbols/CompilationUnitSymbols.h" for slang::ast::DefinitionSymbol
src/slang_frontend.cc:                   #include <cstdlib> for strtol
src/slang_frontend.cc:                   #include <string.h> for strncmp
src/slang_frontend.cc:                   #include "slang/ast/types/AllTypes.h" for slang::ast::UnpackedStructType
src/slang_frontend.cc:                   #include "slang/ast/symbols/CheckerSymbols.h" for slang::ast::CheckerInstanceBodySymbol
src/slang_frontend.cc:                   #include "slang/ast/expressions/AssignmentExpressions.h" for slang::ast::SimpleAssignmentPatternExpression
```