### PR TITLE
[bug] Fix hierarchical ref in root scope segmentation fault

### DIFF
--- a/src/diag.cc
+++ b/src/diag.cc
@@ -135,6 +135,7 @@ DiagCode ReadmemAddressOutsideOfRange(DiagSubsystem::Netlist, 1081);
 DiagCode ReadmemWordsRangeMismatch(DiagSubsystem::Netlist, 1082);
 DiagCode ReadmemBadBinaryDigit(DiagSubsystem::Netlist, 1083);
 DiagCode NoIgnoreUnknownModules(DiagSubsystem::Netlist, 1084);
+DiagCode HierarchicalRefOutsideModulesUnsupported(DiagSubsystem::Netlist, 1085);
 
 DiagGroup unsynthesizable("unsynthesizable",
 		{IffUnsupported, GenericTimingUnsyn, BothEdgesUnsupported, ExpectingIfElseAload,
@@ -357,6 +358,9 @@ void setup_messages(slang::DiagnosticEngine &engine)
 
 	engine.setMessage(NoIgnoreUnknownModules, "'--ignore-unknown-modules' no longer supported with yosys-slang; visit https://github.com/povik/yosys-slang/wiki/No-unknown-modules");
 	engine.setSeverity(NoIgnoreUnknownModules, DiagnosticSeverity::Error);
+
+	engine.setMessage(HierarchicalRefOutsideModulesUnsupported, "hierarchical reference outside module hierarchy unsupported");
+	engine.setSeverity(HierarchicalRefOutsideModulesUnsupported, DiagnosticSeverity::Error);
 	// clang-format on
 }
 }; // namespace diag

--- a/src/diag.h
+++ b/src/diag.h
@@ -89,6 +89,7 @@ extern slang::DiagCode ReadmemAddressOutsideOfRange;
 extern slang::DiagCode ReadmemWordsRangeMismatch;
 extern slang::DiagCode ReadmemBadBinaryDigit;
 extern slang::DiagCode NoIgnoreUnknownModules;
+extern slang::DiagCode HierarchicalRefOutsideModulesUnsupported;
 
 void setup_messages(slang::DiagnosticEngine &engine);
 }; // namespace diag

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -3270,18 +3270,24 @@ bool NetlistContext::should_dissolve(const ast::InstanceSymbol &sym, slang::Diag
 	}
 }
 
-const ast::InstanceBodySymbol &NetlistContext::find_symbol_realm(const ast::Symbol &symbol)
+const ast::InstanceBodySymbol *NetlistContext::find_symbol_realm(const ast::Symbol &symbol)
 {
 	const ast::Scope *scope = symbol.getParentScope();
 
 	while (true) {
 		const ast::Symbol &scope_symbol = scope->asSymbol();
+		if (scope_symbol.kind == ast::SymbolKind::Root) {
+			// For special cases when the hierarchical value
+			// is outside the hierarchy of modules
+			// (e.g. a static variable inside a package).
+			return nullptr;
+		}
 		if (scope_symbol.kind == ast::SymbolKind::InstanceBody) {
 			auto parent = scope_symbol.as<ast::InstanceBodySymbol>().parentInstance;
 			log_assert(parent->getParentScope());
 			if (parent->getParentScope()->asSymbol().kind == ast::SymbolKind::Root
 					|| !should_dissolve(*parent)) {
-				return scope_symbol.as<ast::InstanceBodySymbol>();
+				return &scope_symbol.as<ast::InstanceBodySymbol>();
 			} else {
 				scope = parent->getParentScope();
 			}
@@ -3299,7 +3305,8 @@ const ast::InstanceBodySymbol &NetlistContext::find_common_ancestor(const ast::I
 		path.push_back(body);
 		while (body->parentInstance->getParentScope()->asSymbol().kind !=
 					ast::SymbolKind::Root) {
-			body = &find_symbol_realm(*body->parentInstance);
+			body = find_symbol_realm(*body->parentInstance);
+			log_assert(body);
 			path.push_back(body);
 			log_assert(body->parentInstance);
 			log_assert(body->parentInstance->getParentScope());
@@ -3322,15 +3329,19 @@ const ast::InstanceBodySymbol &NetlistContext::find_common_ancestor(const ast::I
 
 bool NetlistContext::check_hier_ref(const ast::ValueSymbol &symbol, slang::SourceRange range, bool silent)
 {
-	const ast::InstanceBodySymbol &symbol_realm = find_symbol_realm(symbol);
+	const ast::InstanceBodySymbol *symbol_realm = find_symbol_realm(symbol);
+	if (!symbol_realm) {
+		add_diag(diag::HierarchicalRefOutsideModulesUnsupported, range);
+		return false;
+	}
 
-	if (&symbol_realm != &realm) {
+	if (symbol_realm != &realm) {
 		auto &diag = add_diag(diag::ReferenceAcrossKeptHierBoundary, range);
-		auto &common = find_common_ancestor(symbol_realm, realm);
+		auto &common = find_common_ancestor(*symbol_realm, realm);
 		if (!silent) {
-			if (&symbol_realm != &common) {
+			if (symbol_realm != &common) {
 				// emit diagnostic for boundary on the hierarchical path to the symbol
-				(void) should_dissolve(*symbol_realm.parentInstance, &diag);
+				(void) should_dissolve(*symbol_realm->parentInstance, &diag);
 			} else {
 				// emit diagnostic for boundary on the hierarchical path to the expression
 				(void) should_dissolve(*realm.parentInstance, &diag);

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -598,7 +598,7 @@ struct NetlistContext : RTLILBuilder, public DiagnosticIssuer {
 	// Find the "realm" for the given symbol, i.e. the containing instance body
 	// which is not getting dissolved during netlist emission. If we are fully flattening
 	// this will be the top module.
-	const ast::InstanceBodySymbol &find_symbol_realm(const ast::Symbol &symbol);
+	const ast::InstanceBodySymbol *find_symbol_realm(const ast::Symbol &symbol);
 	const ast::InstanceBodySymbol &find_common_ancestor(const ast::InstanceBodySymbol &a, const ast::InstanceBodySymbol &b);
 	bool check_hier_ref(const ast::ValueSymbol &symbol, slang::SourceRange range, bool silent=false);
 

--- a/tests/various/hierref_error.ys
+++ b/tests/various/hierref_error.ys
@@ -62,3 +62,27 @@ module top(inout pad, output out);
 	wire g = i1.w;
 endmodule
 EOF
+
+design -reset
+test_slangdiag -expect "hierarchical reference outside module hierarchy unsupported"
+read_slang <<EOF
+package p;
+   struct { int x; } s1;
+   struct { int x; } s2;
+   function void f();
+      int x;
+   endfunction
+endpackage
+
+module m;
+   import p::*;
+   if (1) begin : s1
+      initial begin
+         s1.x = 1;
+         s2.x = 1;
+         f.x = 1;
+      end
+      int x;
+   end
+endmodule
+EOF


### PR DESCRIPTION
Hi, all!

For this case, yosys-slang segfaults while trying to resolve a hierarchical reference parent because a static variable inside a package exists outside of module scope:

```verilog
package p;
   struct { int x; } s1;
   struct { int x; } s2;
   function void f();
      int x;
   endfunction
endpackage

module m;
   import p::*;
   if (1) begin : s1
      initial begin
         s1.x = 1;
         s2.x = 1;
         f.x = 1;
      end
      int x;
   end
endmodule
```

I would prefer to use a warning instead.