### PR TITLE
[bug] Fix segfault exporting a blackbox with a user-defined nettype port

### DIFF
--- a/src/blackboxes.cc
+++ b/src/blackboxes.cc
@@ -204,6 +204,11 @@ void export_blackbox_to_rtlil(
 
 	inst.body.visit(ast::makeVisitor(
 			[&](auto &, const ast::PortSymbol &port) {
+				if (port.getType().isFloating()) {
+					netlist.add_diag(diag::UnsupportedBitConversion, port.location)
+							<< port.getType().toString();
+					return;
+				}
 				if (!port.getSyntax() || !port.getType().isFixedSize() || !port.internalSymbol ||
 						!port.internalSymbol->getDeclaredType()) {
 					inst.body.addDiag(diag::BboxExportPortWidths, port.location);

--- a/src/blackboxes.cc
+++ b/src/blackboxes.cc
@@ -209,15 +209,20 @@ void export_blackbox_to_rtlil(
 					inst.body.addDiag(diag::BboxExportPortWidths, port.location);
 				} else {
 					const DeclaredType *dt = port.internalSymbol->getDeclaredType();
-					const SyntaxNode &syntax = *dt->getTypeSyntax();
+					const SyntaxNode *syntax = dt->getTypeSyntax();
 					const SyntaxList<VariableDimensionSyntax> *dims = nullptr;
 					bool rejected = false;
 
-					if (syntax.kind == SyntaxKind::ImplicitType) {
-						auto &impl_type = syntax.as<ImplicitTypeSyntax>();
+					if (!syntax) {
+						// The declared type links to another declaration (e.g. a
+						// user-defined nettype), so there is no inline type syntax
+						// here and thus no packed dimensions on this port to check.
+						// The unpacked dimensions, if any, are still validated below.
+					} else if (syntax->kind == SyntaxKind::ImplicitType) {
+						auto &impl_type = syntax->as<ImplicitTypeSyntax>();
 						dims = &impl_type.dimensions;
-					} else if (IntegerTypeSyntax::isKind(syntax.kind)) {
-						auto &int_type = syntax.as<IntegerTypeSyntax>();
+					} else if (IntegerTypeSyntax::isKind(syntax->kind)) {
+						auto &int_type = syntax->as<IntegerTypeSyntax>();
 						dims = &int_type.dimensions;
 					} else {
 						inst.body.addDiag(diag::BboxExportPortWidths, port.location);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ set(ALL_TESTS
     various/assign_mixing.ys
     various/assignment_pattern_lhs.ys
     various/bb_detect.ys
+    various/bb_nettype_port.ys
     various/blackbox_scenarios.ys
     various/bus_range.ys
     various/concurrent_assert.ys

--- a/tests/various/bb_nettype_port.ys
+++ b/tests/various/bb_nettype_port.ys
@@ -1,7 +1,10 @@
-# Regression: exporting an empty blackbox whose port type is a user-defined
-# nettype used to segfault. The port's DeclaredType links to the nettype's
-# declaration, so DeclaredType::getTypeSyntax() returns nullptr, which was
-# dereferenced unconditionally in export_blackbox_to_rtlil().
+# Exporting an empty blackbox whose port type is a user-defined nettype used to
+# segfault: the port's DeclaredType links to the nettype's declaration, so
+# DeclaredType::getTypeSyntax() returned nullptr and was dereferenced in
+# export_blackbox_to_rtlil(). A real-typed nettype has no faithful RTLIL bit
+# representation, so it must error out cleanly rather than crash (or silently
+# export a bogus logic net).
+test_slangdiag -expect "value of type 'real' is unsupported for conversion to bits in this context"
 read_slang --empty-blackboxes <<SV
 package NetsPkg;
   nettype real realNet;
@@ -16,4 +19,21 @@ module top();
   rDriver r1(.out());
 endmodule
 SV
-select -assert-mod-count 1 =rDriver =A:blackbox %i
+
+# A bit-representable (logic) nettype port is still exported normally.
+design -reset
+read_slang --empty-blackboxes <<SV
+package BusPkg;
+  nettype logic [3:0] busNet;
+endpackage
+
+module bb
+  import BusPkg::*;
+  (output busNet out);
+endmodule
+
+module top();
+  bb u(.out());
+endmodule
+SV
+select -assert-mod-count 1 =bb =A:blackbox %i

--- a/tests/various/bb_nettype_port.ys
+++ b/tests/various/bb_nettype_port.ys
@@ -1,0 +1,19 @@
+# Regression: exporting an empty blackbox whose port type is a user-defined
+# nettype used to segfault. The port's DeclaredType links to the nettype's
+# declaration, so DeclaredType::getTypeSyntax() returns nullptr, which was
+# dereferenced unconditionally in export_blackbox_to_rtlil().
+read_slang --empty-blackboxes <<SV
+package NetsPkg;
+  nettype real realNet;
+endpackage
+
+module rDriver
+  import NetsPkg::*;
+  (output realNet out);
+endmodule
+
+module top();
+  rDriver r1(.out());
+endmodule
+SV
+select -assert-mod-count 1 =rDriver =A:blackbox %i


### PR DESCRIPTION
A port whose type is a user-defined nettype has its `DeclaredType` set up as a link, so `getTypeSyntax()` returns `nullptr`, which `export_blackbox_to_rtlil()` dereferenced unconditionally. This leads to segfault on `read_slang --empty-blackboxes` on this case:

```verilog
package NetsPkg;
  nettype real realNet;
endpackage

module rDriver
  import NetsPkg::*;
  (output realNet out);
endmodule

module top();
  rDriver r1(.out());
endmodule
```