### PR TITLE
bazelignore all of third_party/

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,1 +1,1 @@
-third_party/fmt/support/bazel
+third_party


### PR DESCRIPTION
Since we get fmt from @fmt and slang via specific
bazel vendoring, we don't need submodules or access third_party/ in its entirety.