### PR TITLE
Catch warnings/errors as in yosys

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,13 @@ add_library(yosys-slang ${LIBRARY_TYPE}
 )
 target_include_directories(yosys-slang PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(yosys-slang PRIVATE yosys::yosys slang::slang)
+target_compile_options(yosys-slang PRIVATE 
+    -Wall
+    -Wextra
+    -Werror=unused-variable
+    -Werror=unused-parameter
+    -Werror=unused-function
+)
 
 if (BUILD_AS_PLUGIN)
     set_target_properties(yosys-slang PROPERTIES

--- a/src/builder.cc
+++ b/src/builder.cc
@@ -367,7 +367,7 @@ SigSpec RTLILBuilder::Biop(
 
 	if (op.in(ID($le), ID($lt), ID($gt), ID($ge)) && !a.empty() && !b.empty()) {
 		int carry = op.in(ID($le), ID($ge)) ? -1 : 1;
-		int al, bl;
+		int al = 0, bl = 0;
 		// Defer to three-valued evaluation over a representation of the operators.
 		// This is a bit much, but I'm writing this tired and don't trust doing it
 		// another way.

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -3295,6 +3295,7 @@ bool NetlistContext::should_dissolve(const ast::InstanceSymbol &sym, slang::Diag
 			auto &note = why_not_dissolved->addNote(diag::NoteModuleNotDissolvedBecauseKeepHierarchy, sym.location);
 			note << sym.body.name;
 		}
+		return false;
 	default:
 		return false;
 	}


### PR DESCRIPTION
Actually it was giving error with gcc. I will also make clang to react same way in yosys. This way it should be easier to catch issues for you in future. Also fixed two minor warnings detected with these extra settings