### PR TITLE
Make submodules to use the same protocol as the top one.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "third_party/slang"]
 	path = third_party/slang
-	url = https://github.com/MikePopoloski/slang.git
+	url = ../../MikePopoloski/slang.git
 [submodule "third_party/fmt"]
 	path = third_party/fmt
-	url = https://github.com/fmtlib/fmt
+	url = ../../fmtlib/fmt.git


### PR DESCRIPTION
My firewall does not accept https in git but ssh only (git@github.com:povik/sv-elab.git).
Make submodules urls to use the same protocol as the one used to clone the top git.

OpenROAD as the same:
```
[submodule "module/OpenSTA"]
        path = src/sta
        url = ../../The-OpenROAD-Project/OpenSTA.git
[submodule "src/abc"]
        path = third-party/abc
        url = ../../The-OpenROAD-Project/abc.git
[submodule "third-party/slang-elab"]
        path = third-party/slang-elab
        url = ../../povik/yosys-slang.git
```
