### PR TITLE
async_pattern: match const-comparison reset conditions at widened widths

### DIFF
--- a/src/async_pattern.cc
+++ b/src/async_pattern.cc
@@ -199,26 +199,73 @@ void TimingPatternInterpretor::interpret_async_pattern(const ast::ProceduralBloc
 				did_something = true;
 			}
 
+			// Strip an (in)equality comparison against a constant, i.e. rewrite
+			// `x == C` / `x != C` into `x` or `!x` when that is sound. The
+			// signal operand may have been widened for the comparison (e.g. in
+			// `rst == 1` the comparison is performed at 32 bits per §11.6.1),
+			// so look through widening conversions on the signal side and
+			// extend 1'b0 / 1'b1 the same way those conversions would: the
+			// comparison reduces to `x` (or `!x`) iff C is the image of
+			// exactly one of the two values.
 			if (condition->kind == ast::ExpressionKind::BinaryOp &&
-					condition->as<ast::BinaryExpression>().op == ast::BinaryOperator::Equality &&
-					condition->as<ast::BinaryExpression>().right().getConstant() &&
-					condition->as<ast::BinaryExpression>().right().type->getBitWidth() == 1 &&
-					!condition->as<ast::BinaryExpression>().right().getConstant()->hasUnknown() &&
-					condition->as<ast::BinaryExpression>().right().getConstant()->isTrue()) {
+					(condition->as<ast::BinaryExpression>().op ==
+									ast::BinaryOperator::Equality ||
+							condition->as<ast::BinaryExpression>().op ==
+									ast::BinaryOperator::Inequality)) {
 				auto &biop = condition->as<ast::BinaryExpression>();
-				did_something = true;
-				condition = &biop.left();
-			}
 
-			if (condition->kind == ast::ExpressionKind::BinaryOp &&
-					condition->as<ast::BinaryExpression>().op == ast::BinaryOperator::Equality &&
-					condition->as<ast::BinaryExpression>().right().getConstant() &&
-					!condition->as<ast::BinaryExpression>().right().getConstant()->hasUnknown() &&
-					condition->as<ast::BinaryExpression>().right().getConstant()->isFalse()) {
-				auto &biop = condition->as<ast::BinaryExpression>();
-				polarity = !polarity;
-				did_something = true;
-				condition = &biop.left();
+				const ast::Expression *operand = nullptr;
+				const slang::ConstantValue *constant;
+				if ((constant = biop.right().getConstant()) && !biop.left().getConstant())
+					operand = &biop.left();
+				else if ((constant = biop.left().getConstant()) && !biop.right().getConstant())
+					operand = &biop.right();
+
+				if (operand && constant->isInteger() && !constant->integer().hasUnknown()) {
+					// Find the underlying expression below any widening
+					// integral conversions
+					std::vector<const ast::ConversionExpression *> conversions;
+					const ast::Expression *inner = operand;
+					while (inner->kind == ast::ExpressionKind::Conversion &&
+							inner->type->isIntegral() &&
+							inner->as<ast::ConversionExpression>().operand().type->isIntegral() &&
+							inner->as<ast::ConversionExpression>().operand().type->getBitWidth() <=
+									inner->type->getBitWidth()) {
+						conversions.push_back(&inner->as<ast::ConversionExpression>());
+						inner = &inner->as<ast::ConversionExpression>().operand();
+					}
+
+					if (inner->type->isIntegral() && inner->type->getBitWidth() == 1 &&
+							operand->type->getBitWidth() ==
+									constant->integer().getBitWidth()) {
+						// The images of 1'b0 / 1'b1 under the stripped
+						// conversions (zero or sign extension per the source
+						// type of each conversion step; zero's image is zero
+						// either way)
+						slang::SVInt image_one(1, 1, inner->type->isSigned());
+						for (auto it = conversions.rbegin(); it != conversions.rend(); it++) {
+							image_one = image_one.extend(
+									(*it)->type->getBitWidth(), image_one.isSigned());
+							image_one.setSigned((*it)->type->isSigned());
+						}
+						slang::SVInt image_zero(operand->type->getBitWidth(), 0, false);
+
+						bool matches_one = exactlyEqual(constant->integer(), image_one);
+						bool matches_zero = exactlyEqual(constant->integer(), image_zero);
+
+						// If C is the image of exactly one of the two values,
+						// the comparison reduces to the underlying expression
+						// up to polarity; otherwise the comparison is constant
+						// and there is nothing to match against the event list
+						if (matches_one != matches_zero) {
+							if (matches_zero !=
+									(biop.op == ast::BinaryOperator::Inequality))
+								polarity = !polarity;
+							condition = inner;
+							did_something = true;
+						}
+					}
+				}
 			}
 
 			if (condition->kind == ast::ExpressionKind::Conversion &&

--- a/tests/various/aload_cond_const_cmp.ys
+++ b/tests/various/aload_cond_const_cmp.ys
@@ -1,0 +1,111 @@
+# Async-load condition spelled as a comparison against a constant: all of
+# `rst == 1` / `rst == 1'b1` / `rst != 0` / `1 == rst` (and the negated
+# spellings on negedge) must be matched against the event list just like the
+# bare `rst` condition. The comparison may be performed at a widened width
+# (e.g. `rst == 1` compares at 32 bits), which used to defeat the matcher.
+
+read_slang <<EOF
+module aload_eq_unsized(input logic clk, rst, d, output logic q);
+    always_ff @(posedge clk or posedge rst)
+        if (rst == 1) q <= 1'b0;
+        else q <= d;
+endmodule
+EOF
+select -assert-count 1 t:$aldff
+select -assert-count 1 t:$aldff r:ALOAD_POLARITY=1 %i
+select -assert-count 1 t:$aldff %ci:+[ALOAD] w:rst %d
+
+design -reset
+read_slang <<EOF
+module aload_eq_sized(input logic clk, rst, d, output logic q);
+    always_ff @(posedge clk or posedge rst)
+        if (rst == 1'b1) q <= 1'b0;
+        else q <= d;
+endmodule
+EOF
+select -assert-count 1 t:$aldff
+select -assert-count 1 t:$aldff r:ALOAD_POLARITY=1 %i
+select -assert-count 1 t:$aldff %ci:+[ALOAD] w:rst %d
+
+design -reset
+read_slang <<EOF
+module aload_neq_zero(input logic clk, rst, d, output logic q);
+    always_ff @(posedge clk or posedge rst)
+        if (rst != 0) q <= 1'b0;
+        else q <= d;
+endmodule
+EOF
+select -assert-count 1 t:$aldff
+select -assert-count 1 t:$aldff r:ALOAD_POLARITY=1 %i
+select -assert-count 1 t:$aldff %ci:+[ALOAD] w:rst %d
+
+design -reset
+read_slang <<EOF
+module aload_eq_swapped(input logic clk, rst, d, output logic q);
+    always_ff @(posedge clk or posedge rst)
+        if (1 == rst) q <= 1'b0;
+        else q <= d;
+endmodule
+EOF
+select -assert-count 1 t:$aldff
+select -assert-count 1 t:$aldff r:ALOAD_POLARITY=1 %i
+select -assert-count 1 t:$aldff %ci:+[ALOAD] w:rst %d
+
+design -reset
+read_slang <<EOF
+module aload_eq_parens(input logic clk, rst, d, output logic q);
+    always_ff @(posedge clk or posedge rst)
+        if (((rst == 1))) q <= 1'b0;
+        else q <= d;
+endmodule
+EOF
+select -assert-count 1 t:$aldff
+select -assert-count 1 t:$aldff r:ALOAD_POLARITY=1 %i
+
+design -reset
+read_slang <<EOF
+module aload_negedge_eq_zero(input logic clk, rst_n, d, output logic q);
+    always_ff @(posedge clk or negedge rst_n)
+        if (rst_n == 0) q <= 1'b0;
+        else q <= d;
+endmodule
+EOF
+select -assert-count 1 t:$aldff
+select -assert-count 1 t:$aldff r:ALOAD_POLARITY=0 %i
+select -assert-count 1 t:$aldff %ci:+[ALOAD] w:rst_n %d
+
+design -reset
+read_slang <<EOF
+module aload_negedge_neq_one(input logic clk, rst_n, d, output logic q);
+    always_ff @(posedge clk or negedge rst_n)
+        if (rst_n != 1) q <= 1'b0;
+        else q <= d;
+endmodule
+EOF
+select -assert-count 1 t:$aldff
+select -assert-count 1 t:$aldff r:ALOAD_POLARITY=0 %i
+select -assert-count 1 t:$aldff %ci:+[ALOAD] w:rst_n %d
+
+# A comparison against a constant that is the image of NEITHER 1'b0 nor 1'b1
+# is a constant condition and must still be rejected, not silently matched.
+design -reset
+test_slangdiag -expect "condition cannot be matched to any signal from the event list"
+read_slang <<EOF
+module aload_eq_two(input logic clk, rst, d, output logic q);
+    always_ff @(posedge clk or posedge rst)
+        if (rst == 2) q <= 1'b0;
+        else q <= d;
+endmodule
+EOF
+
+# For a SIGNED 1-bit signal, `s == 1` sign-extends `s` for the comparison, so
+# it is constant-false and must not be treated as the async-load condition.
+design -reset
+test_slangdiag -expect "condition cannot be matched to any signal from the event list"
+read_slang <<EOF
+module aload_eq_one_signed(input logic clk, d, output logic q, input logic signed s);
+    always_ff @(posedge clk or posedge s)
+        if (s == 1) q <= 1'b0;
+        else q <= d;
+endmodule
+EOF


### PR DESCRIPTION
## Problem

The async-load condition matcher in `interpret_async_pattern` normalizes `x == C` conditions only when the comparison is performed at 1 bit (`rst == 1'b1`), or when `C` is zero. The very common spelling

```verilog
always @(posedge clk or posedge rst)
    if (rst == 1) q <= 1'b0;   // unsized literal: comparison at 32 bits
    else q <= d;
```

compares at 32 bits (IEEE 1800-2017 §11.6.1), so the equality is never stripped and elaboration fails with

```
error: condition cannot be matched to any signal from the event list
```

on spec-legal RTL that commercial tools accept. Hit in the wild by OpenPiton (`piton/design/chipset/noc_sd_bridge/rtl/byte_en_reg.v`), and `!=` conditions (`if (rst != 0)`, negedge `if (rst_n != 1)`) are not handled at all.

## Fix

Generalize the two constant-comparison rules soundly: for `x == C` / `x != C` with a known constant `C` on either side, look through the widening integral conversions on the signal side and reduce the comparison to `x` or `!x` exactly when `C` is the image of exactly one of `1'b1` / `1'b0` under those conversions (zero- or sign-extension per each conversion step's source type).

- Accepts `rst == 1`, `rst != 0`, `1 == rst`, `rst_n == 0`, `rst_n != 1`, and the signed sign-extension image (`s == -1` for 1-bit signed `s`).
- Still rejects constant conditions like `rst == 2` (image of neither value) and the sign-extension trap `s == 1` for 1-bit signed `s` (constant false), so the match stays semantically implied by the edge polarity.
- Subsumes the previous 1-bit-true and zero-constant special cases unchanged.

## Validation

Developed and fully validated at f3804697 (the commit partcleda/boson pins; RTLIL for `if (rst == 1)` is byte-identical modulo `src` attributes to the `if (rst)` spelling, full test suite green there, 52/52). This branch is the clean cherry-pick onto current master (context applied without conflicts); please let CI confirm on master's vendored slang. New test: `tests/various/aload_cond_const_cmp.ys` covering all accepted spellings plus the two must-still-reject cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
